### PR TITLE
docs(client-ephemeral-independent): move internal type to file exported

### DIFF
--- a/experimental/dds/ephemeral-independent/api-report/ephemeral-independent.api.md
+++ b/experimental/dds/ephemeral-independent/api-report/ephemeral-independent.api.md
@@ -15,6 +15,12 @@ import type { Serializable } from '@fluidframework/datastore-definitions';
 // @alpha (undocumented)
 export type ClientId = string;
 
+// @internal (undocumented)
+interface ClientRecord<TValue extends ValueDirectoryOrState<any>> {
+    // (undocumented)
+    [ClientId: ClientId]: TValue;
+}
+
 // @alpha (undocumented)
 export type EmptyIndependentMap = IndependentMap<{}>;
 
@@ -70,7 +76,8 @@ declare namespace InternalTypes {
         IndependentDatastoreHandle,
         IndependentValueBrand,
         IndependentValue,
-        ManagerFactory
+        ManagerFactory,
+        ClientRecord
     }
 }
 export { InternalTypes }

--- a/experimental/dds/ephemeral-independent/src/exposedInternalTypes.ts
+++ b/experimental/dds/ephemeral-independent/src/exposedInternalTypes.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { RoundTrippable } from "./baseTypes.js";
+import type { ClientId, RoundTrippable } from "./baseTypes.js";
 
 /**
  * @alpha
@@ -76,3 +76,13 @@ export type ManagerFactory<
 	value: TValue;
 	manager: IndependentValue<TManager>;
 };
+
+/**
+ * @internal
+ */
+export interface ClientRecord<TValue extends ValueDirectoryOrState<any>> {
+	// Caution: any particular item may or may not exist
+	// Typescript does not support absent keys without forcing type to also be undefined.
+	// See https://github.com/microsoft/TypeScript/issues/42810.
+	[ClientId: ClientId]: TValue;
+}

--- a/experimental/dds/ephemeral-independent/src/independentDatastore.ts
+++ b/experimental/dds/ephemeral-independent/src/independentDatastore.ts
@@ -4,8 +4,11 @@
  */
 
 import type { ClientId } from "./baseTypes.js";
-import type { IndependentDatastoreHandle, ValueDirectoryOrState } from "./exposedInternalTypes.js";
-import type { ClientRecord } from "./internalTypes.js";
+import type {
+	ClientRecord,
+	IndependentDatastoreHandle,
+	ValueDirectoryOrState,
+} from "./exposedInternalTypes.js";
 
 // type IndependentDatastoreSchemaNode<
 // 	TValue extends ValueDirectoryOrState<any> = ValueDirectoryOrState<unknown>,

--- a/experimental/dds/ephemeral-independent/src/independentMap.ts
+++ b/experimental/dds/ephemeral-independent/src/independentMap.ts
@@ -8,6 +8,7 @@ import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitio
 import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 
 import type {
+	ClientRecord,
 	ManagerFactory,
 	ValueDirectory,
 	ValueDirectoryOrState,
@@ -15,7 +16,6 @@ import type {
 } from "./exposedInternalTypes.js";
 import { handleFromDatastore, type IndependentDatastore } from "./independentDatastore.js";
 import { unbrandIVM } from "./independentValue.js";
-import type { ClientRecord } from "./internalTypes.js";
 import type { IndependentMap, IndependentMapMethods, IndependentMapSchema } from "./types.js";
 
 interface IndependentMapValueUpdate<TValue extends ValueDirectoryOrState<any>> {

--- a/experimental/dds/ephemeral-independent/src/internalTypes.ts
+++ b/experimental/dds/ephemeral-independent/src/internalTypes.ts
@@ -9,16 +9,6 @@ import { ValueDirectoryOrState } from "./exposedInternalTypes.js";
 /**
  * @internal
  */
-export interface ClientRecord<TValue extends ValueDirectoryOrState<any>> {
-	// Caution: any particular item may or may not exist
-	// Typescript does not support absent keys without forcing type to also be undefined.
-	// See https://github.com/microsoft/TypeScript/issues/42810.
-	[ClientId: ClientId]: TValue;
-}
-
-/**
- * @internal
- */
 export interface ValueManager<
 	TValue,
 	TValueState extends ValueDirectoryOrState<TValue> = ValueDirectoryOrState<TValue>,


### PR DESCRIPTION
results in api report exposure (accurate for untrimmed)