### PR TITLE
improvement: `JsonString` for container-runtime

### DIFF
--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -119,8 +119,8 @@ export interface IRuntime extends IDisposable {
  * @legacy
  * @alpha
  */
-export interface IBatchMessage {
-	contents?: string;
+export interface IBatchMessage<TContents extends string = string> {
+	contents?: TContents;
 	metadata?: Record<string, unknown>;
 	compression?: string;
 	referenceSequenceNumber?: number;

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -36,11 +36,11 @@
 		"./internal": {
 			"import": {
 				"types": "./lib/internal.d.ts",
-				"default": "./lib/index.js"
+				"default": "./lib/internal.js"
 			},
 			"require": {
 				"types": "./dist/internal.d.ts",
-				"default": "./dist/index.js"
+				"default": "./dist/internal.js"
 			}
 		},
 		"./internal/exposedUtilityTypes": {

--- a/packages/common/core-interfaces/src/internal.ts
+++ b/packages/common/core-interfaces/src/internal.ts
@@ -6,9 +6,8 @@
 // eslint-disable-next-line no-restricted-syntax
 export * from "./index.js";
 
-// Important: all other exports must be type only exports. In package.json exports,
-//  index.js is listed as the runtime file. This is done so that all imports are
-//  using the same outer runtime file. (Could be changed if needed.)
+export type { JsonString } from "./jsonString.js";
+export { JsonStringify, JsonParse } from "./jsonString.js";
 
 // Export set of utility types re-tagged as internal for FF client convenience.
 // These types are not intended for direct use by customers and api-extractor will

--- a/packages/common/core-interfaces/src/jsonString.ts
+++ b/packages/common/core-interfaces/src/jsonString.ts
@@ -1,0 +1,62 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { JsonDeserialized } from "./jsonDeserialized.js";
+import type { JsonSerializable } from "./jsonSerializable.js";
+
+/**
+ * Base branded type
+ */
+declare class BrandedType<Brand> {
+	protected readonly brand: (dummy: never) => Brand;
+	protected constructor();
+	public static [Symbol.hasInstance](value: never): value is never;
+}
+
+/**
+ * Brand for JSON that has been stringified.
+ *
+ * Usage:
+ *
+ * - Cast to with `as unknown as JsonStringBrand<T>` when value of type `T` has been stringified.
+ *
+ * - Cast from with `as unknown as string` when "instance" will be parsed to `T`.
+ *
+ * @sealed
+ * @internal
+ */
+declare class JsonStringBrand<T> extends BrandedType<T> {
+	public toString(): string;
+	private readonly EncodedValue: T;
+	private constructor();
+}
+
+/**
+ * Branded `string` for JSON that has been stringified.
+ *
+ * Usage:
+ *
+ * - Cast to with `as unknown as JsonString<T>` when value of type `T` has been stringified.
+ *
+ * - Cast from with `as unknown as string` when "instance" will be parsed to `T`.
+ *
+ * @sealed
+ * @internal
+ */
+export type JsonString<T> = string & JsonStringBrand<T>;
+
+/**
+ * @internal
+ */
+export const JsonStringify = JSON.stringify as <T>(
+	value: JsonSerializable<T, { AllowExactly: [unknown] }>,
+) => JsonString<T>;
+
+/**
+ * @internal
+ */
+export const JsonParse: <T>(
+	text: JsonString<T>,
+) => JsonDeserialized<T, { AllowExactly: [unknown] }> = JSON.parse;

--- a/packages/common/driver-definitions/src/protocol/protocol.ts
+++ b/packages/common/driver-definitions/src/protocol/protocol.ts
@@ -254,7 +254,7 @@ export interface ISequencedDocumentMessage {
 	/**
 	 * The contents of the message.
 	 */
-	contents: unknown;
+	contents?: unknown;
 
 	/**
 	 * App provided metadata about the operation.

--- a/packages/runtime/container-runtime/.eslintrc.cjs
+++ b/packages/runtime/container-runtime/.eslintrc.cjs
@@ -48,6 +48,7 @@ module.exports = {
 		"@typescript-eslint/no-unsafe-call": "error",
 		"@typescript-eslint/no-unsafe-member-access": "error",
 		"@typescript-eslint/no-unsafe-return": "error",
+		"@typescript-eslint/no-unnecessary-type-arguments": "warn",
 
 		"jsdoc/multiline-blocks": ["error", { noSingleLineBlocks: true }],
 		"jsdoc/require-description": ["error", { checkConstructors: false }],

--- a/packages/runtime/container-runtime/src/messageTypes.ts
+++ b/packages/runtime/container-runtime/src/messageTypes.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { InternalUtilityTypes } from "@fluidframework/core-interfaces/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type { IdCreationRange } from "@fluidframework/id-compressor/internal";
 import {
@@ -66,16 +67,25 @@ export enum ContainerMessageType {
  * IMPORTANT: when creating one to be serialized, set the properties in the order they appear here.
  * This way stringified values can be compared.
  */
-interface TypedContainerRuntimeMessage<TType extends ContainerMessageType, TContents> {
+type TypedContainerRuntimeMessage<TType extends ContainerMessageType, TContents> = {
 	/**
 	 * Type of the op, within the ContainerRuntime's domain
 	 */
 	type: TType;
-	/**
-	 * Domain-specific contents, interpreted according to the type
-	 */
-	contents: TContents;
-}
+} & InternalUtilityTypes.IfSameType<
+	TContents,
+	undefined,
+	{
+		// No `contents` when type is `undefined`
+		contents?: undefined;
+	},
+	{
+		/**
+		 * Domain-specific contents, interpreted according to the type
+		 */
+		contents: TContents;
+	}
+>;
 
 export type ContainerRuntimeDataStoreOpMessage = TypedContainerRuntimeMessage<
 	ContainerMessageType.FluidDataStoreOp,
@@ -115,7 +125,6 @@ export type ContainerRuntimeGCMessage = TypedContainerRuntimeMessage<
 >;
 export type ContainerRuntimeDocumentSchemaMessage = TypedContainerRuntimeMessage<
 	ContainerMessageType.DocumentSchemaChange,
-	// eslint-disable-next-line import/no-deprecated
 	IDocumentSchemaChangeMessage
 >;
 
@@ -134,7 +143,7 @@ export interface UnknownContainerRuntimeMessage {
 	/**
 	 * Domain-specific contents, but not decipherable by an unknown op.
 	 */
-	contents: unknown;
+	contents?: unknown;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
@@ -4,13 +4,23 @@
  */
 
 import { IBatchMessage } from "@fluidframework/container-definitions/internal";
+import type { JsonString } from "@fluidframework/core-interfaces/internal";
 
 import { CompressionAlgorithms } from "../containerRuntime.js";
+import type { LocalContainerRuntimeMessage } from "../messageTypes.js";
+
+import type { IPackedContentsContents } from "./opDecompressor.js";
+import type { IGroupedBatchMessageContents } from "./opGroupingManager.js";
 
 /**
  * Batch message type used internally by the runtime
  */
-export type BatchMessage = IBatchMessage & {
+export type BatchMessage<
+	TStringifiedContents extends
+		| LocalContainerRuntimeMessage
+		| IGroupedBatchMessageContents
+		| IPackedContentsContents = LocalContainerRuntimeMessage,
+> = IBatchMessage<JsonString<TStringifiedContents>> & {
 	localOpMetadata?: unknown;
 	referenceSequenceNumber: number;
 	compression?: CompressionAlgorithms;
@@ -19,7 +29,12 @@ export type BatchMessage = IBatchMessage & {
 /**
  * Batch interface used internally by the runtime.
  */
-export interface IBatch<TMessages extends BatchMessage[] = BatchMessage[]> {
+export interface IBatch<
+	TMessages extends
+		| BatchMessage<LocalContainerRuntimeMessage>[]
+		| BatchMessage<IGroupedBatchMessageContents>[]
+		| BatchMessage<IPackedContentsContents>[],
+> {
 	/**
 	 * Sum of the in-memory content sizes of all messages in the batch.
 	 * If the batch is compressed, this number reflects the post-compression size.
@@ -57,7 +72,7 @@ export interface IChunkedOp {
 	chunkId: number;
 	totalChunks: number;
 	contents: string;
-	originalMetadata?: Record<string, unknown>;
+	originalMetadata?: { [P in string]?: unknown };
 	originalCompression?: string;
 }
 

--- a/packages/runtime/container-runtime/src/opLifecycle/index.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/index.ts
@@ -17,6 +17,7 @@ export { DuplicateBatchDetector } from "./duplicateBatchDetector.js";
 export { Outbox, getLongStack, serializeOpContents } from "./outbox.js";
 export { OpCompressor } from "./opCompressor.js";
 export { OpDecompressor } from "./opDecompressor.js";
+export type { IGroupedBatchMessageContents } from "./opGroupingManager.js";
 export { OpSplitter, splitOp, isChunkedMessage } from "./opSplitter.js";
 export {
 	ensureContentsDeserialized,

--- a/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
@@ -19,7 +19,7 @@ import { IBatchMetadata } from "../metadata.js";
 /**
  * Compression makes assumptions about the shape of message contents. This interface codifies those assumptions, but does not validate them.
  */
-interface IPackedContentsContents {
+export interface IPackedContentsContents {
 	packedContents: string;
 }
 

--- a/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
@@ -18,6 +18,8 @@ import { ContainerMessageType, ContainerRuntimeChunkedOpMessage } from "../messa
 
 import { estimateSocketSize } from "./batchManager.js";
 import { BatchMessage, IBatch, IChunkedOp } from "./definitions.js";
+import type { IPackedContentsContents } from "./opDecompressor.js";
+import { JsonStringify } from "@fluidframework/core-interfaces/internal";
 
 export function isChunkedMessage(message: ISequencedDocumentMessage): boolean {
 	return isChunkedContents(message.contents);
@@ -122,7 +124,7 @@ export class OpSplitter {
 	 * @param batch - the compressed batch which needs to be processed
 	 * @returns A batch with the last chunk of the original message
 	 */
-	public splitFirstBatchMessage(batch: IBatch): IBatch {
+	public splitFirstBatchMessage(batch: IBatch<BatchMessage<IPackedContentsContents>[]>): IBatch {
 		assert(this.isBatchChunkingEnabled, 0x513 /* Chunking needs to be enabled */);
 		assert(
 			batch.contentSizeInBytes > 0 && batch.messages.length > 0,
@@ -249,7 +251,7 @@ const chunkToBatchMessage = (
 		contents: chunk,
 	};
 	return {
-		contents: JSON.stringify(payload),
+		contents: JsonStringify(payload),
 		metadata,
 		referenceSequenceNumber,
 	};

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -67,7 +67,7 @@ export interface IDocumentSchema {
 	// Sequence number when this schema became active.
 	refSeq: number;
 
-	runtime: Record<string, DocumentSchemaValueType>;
+	runtime: Record<string, Exclude<DocumentSchemaValueType, undefined>>;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -41,6 +41,7 @@ import {
 	PendingStateManager,
 	type IPendingMessage,
 } from "../../pendingStateManager.js";
+import type { IPackedContentsContents } from "../../opLifecycle/opDecompressor.js";
 
 function typeFromBatchedOp(op: IBatchMessage) {
 	assert(op.contents !== undefined);
@@ -110,7 +111,7 @@ describe("Outbox", () => {
 	});
 
 	const getMockCompressor = (): Partial<OpCompressor> => ({
-		compressBatch: (batch: IBatch<[BatchMessage]>): IBatch<[BatchMessage]> => {
+		compressBatch: (batch: IBatch<[BatchMessage]>): IBatch<[BatchMessage<IPackedContentsContents>]> => {
 			state.batchesCompressed.push(batch);
 			return batch;
 		},

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -23,8 +23,7 @@ export interface IEnvelope {
 	/**
 	 * The contents of the envelope
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO (#28746): breaking change
-	contents: any;
+	contents?: unknown;
 }
 
 /**


### PR DESCRIPTION
brand Json stringified string with the type of content serialized. Use that for safer serialization and deserialization.