### PR TITLE
improvement(client): cleanup getPresence via fluid-framework docs

### DIFF
--- a/.changeset/beige-candles-sleep.md
+++ b/.changeset/beige-candles-sleep.md
@@ -3,7 +3,7 @@
 "@fluidframework/presence": minor
 "__section": deprecation
 ---
-getPresence is being relocated to fluid-framework package away from @fluidframework/presence
+getPresence is being relocated from @fluidframework/presence to the fluid-framework package
 
 To prepare, make changes following this pattern:
 ```diff

--- a/.changeset/beige-candles-sleep.md
+++ b/.changeset/beige-candles-sleep.md
@@ -1,0 +1,14 @@
+---
+"fluid-framework": minor
+"@fluidframework/presence": minor
+"__section": deprecation
+---
+getPresence is being relocated to fluid-framework package away from @fluidframework/presence
+
+To prepare, make changes following this pattern:
+```diff
+-import { getPresence } from "@fluidframework/presence/beta";
++import { getPresence } from "fluid-framework/beta";
+```
+
+See [issue #26397](https://github.com/microsoft/FluidFramework/issues/26397) for more details.

--- a/docs/docs/build/presence.mdx
+++ b/docs/docs/build/presence.mdx
@@ -173,7 +173,7 @@ function logOthersCounters(counterTracker: LatestMap<number, string>): void {
 To access Presence APIs, use `getPresence()` with any `IFluidContainer`.
 
 ```typescript
-import { getPresence } from "@fluidframework/presence/beta";
+import { getPresence } from "fluid-framework/beta";
 
 function usePresence(container: IFluidContainer): void {
    const presence = getPresence(container);

--- a/examples/apps/presence-tracker/src/app.ts
+++ b/examples/apps/presence-tracker/src/app.ts
@@ -3,13 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import {
-	getPresence,
-	type AttendeeId,
-	type AttendeeStatus,
-} from "@fluidframework/presence/beta";
+import type { AttendeeId, AttendeeStatus } from "@fluidframework/presence/beta";
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
 import type { ContainerSchema, IFluidContainer } from "fluid-framework";
+import { getPresence } from "fluid-framework/beta";
 
 import { FocusTracker } from "./FocusTracker.js";
 import { MouseTracker } from "./MouseTracker.js";

--- a/examples/service-clients/azure-client/external-controller/src/app.ts
+++ b/examples/service-clients/azure-client/external-controller/src/app.ts
@@ -5,9 +5,9 @@
 
 import { AzureClient, type AzureContainerServices } from "@fluidframework/azure-client";
 import { createDevtoolsLogger, initializeDevtools } from "@fluidframework/devtools/beta";
-import { getPresence } from "@fluidframework/presence/beta";
 import { createChildLogger } from "@fluidframework/telemetry-utils/legacy";
 import type { IFluidContainer } from "fluid-framework";
+import { getPresence } from "fluid-framework/beta";
 
 import { DiceRollerController, type DieValue } from "./controller.js";
 import {

--- a/packages/common/core-interfaces/api-extractor-lint.json
+++ b/packages/common/core-interfaces/api-extractor-lint.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
-}

--- a/packages/common/core-interfaces/api-extractor/api-extractor-lint-internal-exposedUtilityTypes.esm.json
+++ b/packages/common/core-interfaces/api-extractor/api-extractor-lint-internal-exposedUtilityTypes.esm.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/api-extractor/exposedUtilityTypes.d.ts"
+}

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -4,6 +4,13 @@
 
 ```ts
 
+// @beta
+export class BrandedType<out Brand> {
+    static [Symbol.hasInstance](value: never): value is never;
+    protected constructor();
+    protected readonly brand: (dummy: never) => Brand;
+}
+
 // @public
 export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
@@ -4,6 +4,13 @@
 
 ```ts
 
+// @beta
+export class BrandedType<out Brand> {
+    static [Symbol.hasInstance](value: never): value is never;
+    protected constructor();
+    protected readonly brand: (dummy: never) => Brand;
+}
+
 // @public
 export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -83,6 +83,7 @@
 		"check:exports:cjs:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.cjs.json",
 		"check:exports:cjs:legacy.alpha": "api-extractor run --config api-extractor/api-extractor-lint-legacy.alpha.cjs.json",
 		"check:exports:cjs:public": "api-extractor run --config api-extractor/api-extractor-lint-public.cjs.json",
+		"check:exports:esm:internal/exposedUtilityTypes": "api-extractor run --config api-extractor/api-extractor-lint-internal-exposedUtilityTypes.esm.json",
 		"check:exports:esm:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.esm.json",
 		"check:exports:esm:legacy.alpha": "api-extractor run --config api-extractor/api-extractor-lint-legacy.alpha.esm.json",
 		"check:exports:esm:public": "api-extractor run --config api-extractor/api-extractor-lint-public.esm.json",

--- a/packages/common/core-interfaces/src/api-extractor/exposedUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/api-extractor/exposedUtilityTypes.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// This is a workaround for api-extractor to see that "./index.js" exports are
+// covered for the "internal/exposedUtilityTypes" entry point. This file
+// re-exports everything from index.js and the exposedUtilityTypes.js files,
+// which allows api-extractor to verify that all exports from both files are
+// exported somewhere by the package.
+
+/* eslint-disable no-restricted-syntax */
+
+// The "internal" exports are a superset of the standard ones. So, we want to export everything from the standard barrel file.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+export type * from "../index.js";
+
+export type * from "../exposedUtilityTypes.js";

--- a/packages/common/core-interfaces/src/brandedType.ts
+++ b/packages/common/core-interfaces/src/brandedType.ts
@@ -69,7 +69,7 @@
  * }
  * ```
  *
- * @internal
+ * @beta
  */
 export declare class BrandedType<out Brand> {
 	/**

--- a/packages/common/core-interfaces/src/deepReadonly.ts
+++ b/packages/common/core-interfaces/src/deepReadonly.ts
@@ -16,6 +16,7 @@ import type {
  * @privateRemarks
  * WeakRef should be added when lib is updated to ES2021 or later.
  *
+ * @beta
  * @system
  */
 export type DeepReadonlySupportedGenericsDefault =

--- a/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
@@ -20,7 +20,7 @@ import type { OpaqueJsonDeserialized, OpaqueJsonSerializable } from "./opaqueJso
 const RecursionMarkerSymbol: unique symbol = Symbol("recursion here");
 
 /**
- * Union of types that {@link DeepReadonly} and {@link ShallowReadonly}
+ * Union of types that {@link DeepReadonly} and {@link @fluidframework/core-interfaces#ShallowReadonly}
  * recognize to generate immutable form and optionally can alter their
  * type parameters.
  *
@@ -551,7 +551,7 @@ export namespace InternalUtilityTypes {
 	 * @typeParam IfNoMatch - Type to return if no match is found.
 	 *
 	 * @remarks
-	 * In a recursive context, use {@link InternalUtilityTypes.IfExactTypeInTuple} to manage ancestry.
+	 * In a recursive context, use {@link @fluidframework/core-interfaces#InternalUtilityTypes.IfExactTypeInTuple|InternalUtilityTypes.IfExactTypeInTuple} to manage ancestry.
 	 *
 	 * @privateRemarks
 	 * Perhaps it is a Typescript defect but a simple check that `T` is `never`
@@ -989,7 +989,7 @@ export namespace InternalUtilityTypes {
 	/* eslint-enable @typescript-eslint/no-explicit-any */
 
 	/**
-	 * Helper for {@link JsonSerializableFilter} to determine if a property may
+	 * Helper for {@link @fluidframework/core-interfaces#JsonSerializableFilter} to determine if a property may
 	 * be `undefined` and selects from options for result.
 	 * Since `unknown` is a superset of `undefined`, it is given a special case.
 	 * Additionally since index signatures are inherently optional, `unknown` typed
@@ -1248,7 +1248,7 @@ export namespace InternalUtilityTypes {
 		: never /* unreachable else for infer */;
 
 	/**
-	 * Recurses `T` applying {@link InternalUtilityTypes.JsonDeserializedFilter} up until
+	 * Recurses `T` applying {@link @fluidframework/core-interfaces#InternalUtilityTypes.JsonDeserializedFilter} up until
 	 * `T` is found to be a match of an ancestor type. At that point `T` is wrapped in
 	 * {@link OpaqueJsonDeserialized} to avoid further immediate processing, if
 	 * modification is needed. Caller will need to unwrap the type to continue processing.
@@ -1592,7 +1592,7 @@ export namespace InternalUtilityTypes {
 			: Else;
 
 	/**
-	 * De-multiplexing implementation of {@link DeepReadonly} and {@link ShallowReadonly}
+	 * De-multiplexing implementation of {@link DeepReadonly} and {@link @fluidframework/core-interfaces#ShallowReadonly}
 	 * selecting behavior based on `NoDepthOrRecurseLimit`.
 	 *
 	 * @privateRemarks
@@ -1619,7 +1619,7 @@ export namespace InternalUtilityTypes {
 	// #region ShallowReadonly implementation
 
 	/**
-	 * Outer implementation of {@link ShallowReadonly}.
+	 * Outer implementation of {@link @fluidframework/core-interfaces#ShallowReadonly}.
 	 *
 	 * @privateRemarks
 	 * This utility can be reentrant when generics are deepened.
@@ -1760,7 +1760,7 @@ export namespace InternalUtilityTypes {
 		: /* unreachable else for infer */ never;
 
 	/**
-	 * Recurses `T` applying {@link InternalUtilityTypes.DeepReadonlyWorker} up to `RecurseLimit` times.
+	 * Recurses `T` applying {@link @fluidframework/core-interfaces#InternalUtilityTypes.DeepReadonlyWorker} up to `RecurseLimit` times.
 	 *
 	 * @system
 	 */
@@ -1783,7 +1783,7 @@ export namespace InternalUtilityTypes {
 		: DeepReadonlyWorker<T, DeepenedGenerics, RecurseLimit, TAncestorTypes | T>;
 
 	/**
-	 * Core implementation of {@link InternalUtilityTypes.DeepReadonlyLimitingRecursion}.
+	 * Core implementation of {@link @fluidframework/core-interfaces#InternalUtilityTypes.DeepReadonlyLimitingRecursion}.
 	 *
 	 * @system
 	 */

--- a/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
@@ -551,7 +551,7 @@ export namespace InternalUtilityTypes {
 	 * @typeParam IfNoMatch - Type to return if no match is found.
 	 *
 	 * @remarks
-	 * In a recursive context, use {@link @fluidframework/core-interfaces#InternalUtilityTypes.IfExactTypeInTuple|InternalUtilityTypes.IfExactTypeInTuple} to manage ancestry.
+	 * In a recursive context, use {@link InternalCoreInterfacesUtilityTypes.IfExactTypeInTuple} to manage ancestry.
 	 *
 	 * @privateRemarks
 	 * Perhaps it is a Typescript defect but a simple check that `T` is `never`
@@ -989,7 +989,7 @@ export namespace InternalUtilityTypes {
 	/* eslint-enable @typescript-eslint/no-explicit-any */
 
 	/**
-	 * Helper for {@link @fluidframework/core-interfaces#JsonSerializableFilter} to determine if a property may
+	 * Helper for {@link InternalCoreInterfacesUtilityTypes.JsonSerializableFilter} to determine if a property may
 	 * be `undefined` and selects from options for result.
 	 * Since `unknown` is a superset of `undefined`, it is given a special case.
 	 * Additionally since index signatures are inherently optional, `unknown` typed
@@ -1248,7 +1248,7 @@ export namespace InternalUtilityTypes {
 		: never /* unreachable else for infer */;
 
 	/**
-	 * Recurses `T` applying {@link @fluidframework/core-interfaces#InternalUtilityTypes.JsonDeserializedFilter} up until
+	 * Recurses `T` applying {@link InternalCoreInterfacesUtilityTypes.JsonDeserializedFilter} up until
 	 * `T` is found to be a match of an ancestor type. At that point `T` is wrapped in
 	 * {@link OpaqueJsonDeserialized} to avoid further immediate processing, if
 	 * modification is needed. Caller will need to unwrap the type to continue processing.
@@ -1760,7 +1760,7 @@ export namespace InternalUtilityTypes {
 		: /* unreachable else for infer */ never;
 
 	/**
-	 * Recurses `T` applying {@link @fluidframework/core-interfaces#InternalUtilityTypes.DeepReadonlyWorker} up to `RecurseLimit` times.
+	 * Recurses `T` applying {@link InternalCoreInterfacesUtilityTypes.DeepReadonlyWorker} up to `RecurseLimit` times.
 	 *
 	 * @system
 	 */
@@ -1783,7 +1783,7 @@ export namespace InternalUtilityTypes {
 		: DeepReadonlyWorker<T, DeepenedGenerics, RecurseLimit, TAncestorTypes | T>;
 
 	/**
-	 * Core implementation of {@link @fluidframework/core-interfaces#InternalUtilityTypes.DeepReadonlyLimitingRecursion}.
+	 * Core implementation of {@link InternalCoreInterfacesUtilityTypes.DeepReadonlyLimitingRecursion}.
 	 *
 	 * @system
 	 */

--- a/packages/common/core-interfaces/src/exposedUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedUtilityTypes.ts
@@ -9,7 +9,11 @@
 // Should a customer need access to these types, export should be relocated to
 // index.ts and retagged export from internal.ts may be removed.
 
-export type { DeepReadonly } from "./deepReadonly.js";
+export type {
+	DeepReadonly,
+	DeepReadonlyOptions,
+	DeepReadonlySupportedGenericsDefault,
+} from "./deepReadonly.js";
 export type { JsonDeserialized, JsonDeserializedOptions } from "./jsonDeserialized.js";
 export type { JsonSerializable, JsonSerializableOptions } from "./jsonSerializable.js";
 export type {
@@ -25,6 +29,7 @@ export type { OpaqueJsonDeserialized, OpaqueJsonSerializable } from "./opaqueJso
 export type { ShallowReadonly } from "./shallowReadonly.js";
 
 export type {
+	DeepReadonlyRecursionLimit,
 	InternalUtilityTypes,
 	ReadonlySupportedGenerics,
 } from "./exposedInternalUtilityTypes.js";

--- a/packages/common/core-interfaces/src/exposedUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedUtilityTypes.ts
@@ -7,7 +7,7 @@
 // system level but externally exposed version of utilities are needed.
 // Import via /internal when use is not exposed externally.
 // Should a customer need access to these types, export should be relocated to
-// index.ts and retagged export from internal.ts may be removed.
+// index.ts and the re-tagged export from internal.ts may be removed.
 
 export type {
 	DeepReadonly,
@@ -26,7 +26,11 @@ export type {
 	ReadonlyJsonTypeWith,
 } from "./jsonType.js";
 export type { OpaqueJsonDeserialized, OpaqueJsonSerializable } from "./opaqueJson.js";
-export type { ShallowReadonly } from "./shallowReadonly.js";
+export type {
+	ShallowReadonly,
+	ShallowReadonlyOptions,
+	ShallowReadonlySupportedGenericsDefault,
+} from "./shallowReadonly.js";
 
 export type {
 	DeepReadonlyRecursionLimit,

--- a/packages/common/core-interfaces/src/exposedUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedUtilityTypes.ts
@@ -34,6 +34,7 @@ export type {
 
 export type {
 	DeepReadonlyRecursionLimit,
-	InternalUtilityTypes,
+	// External name is qualified to avoid confusion with similarly named types in other packages.
+	InternalUtilityTypes as InternalCoreInterfacesUtilityTypes,
 	ReadonlySupportedGenerics,
 } from "./exposedInternalUtilityTypes.js";

--- a/packages/common/core-interfaces/src/internal.ts
+++ b/packages/common/core-interfaces/src/internal.ts
@@ -99,7 +99,7 @@ export type OpaqueJsonSerializable<
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace InternalUtilityTypes {
+export namespace InternalCoreInterfacesUtilityTypes {
 	/* eslint-disable jsdoc/require-jsdoc */
 	export type FlattenIntersection<T extends ExposedInternalUtilityTypes.AnyRecord> =
 		ExposedInternalUtilityTypes.FlattenIntersection<T>;

--- a/packages/common/core-interfaces/src/shallowReadonly.ts
+++ b/packages/common/core-interfaces/src/shallowReadonly.ts
@@ -16,6 +16,7 @@ import type { IFluidHandle } from "./handles.js";
  * @privateRemarks
  * WeakRef should be added when lib is updated to ES2021 or later.
  *
+ * @beta
  * @system
  */
 export type ShallowReadonlySupportedGenericsDefault = Promise<unknown> | IFluidHandle;

--- a/packages/common/core-interfaces/src/test/jsonDeserialized.spec.ts
+++ b/packages/common/core-interfaces/src/test/jsonDeserialized.spec.ts
@@ -9,7 +9,7 @@ import { strict as assert } from "node:assert";
 
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type {
-	InternalUtilityTypes,
+	InternalCoreInterfacesUtilityTypes as InternalUtilityTypes,
 	JsonDeserialized,
 	JsonTypeWith,
 	NonNullJsonObjectWith,

--- a/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
+++ b/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
@@ -9,7 +9,7 @@ import { strict as assert } from "node:assert";
 
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type {
-	InternalUtilityTypes,
+	InternalCoreInterfacesUtilityTypes as InternalUtilityTypes,
 	JsonDeserialized,
 	JsonSerializable,
 	JsonSerializableOptions,

--- a/packages/common/core-interfaces/src/test/testValues.ts
+++ b/packages/common/core-interfaces/src/test/testValues.ts
@@ -16,7 +16,7 @@ import type {
 } from "@fluidframework/core-interfaces/internal";
 import type {
 	JsonTypeWith,
-	InternalUtilityTypes,
+	InternalCoreInterfacesUtilityTypes as InternalUtilityTypes,
 	ReadonlyJsonTypeWith,
 	NonNullJsonObjectWith,
 	OpaqueJsonSerializable,

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -514,6 +514,12 @@ export function getBranch<T extends ImplicitFieldSchema | UnsafeUnknownSchema>(v
 // @alpha
 export function getJsonSchema(schema: ImplicitAllowedTypes, options: Required<TreeSchemaEncodingOptions>): JsonTreeSchema;
 
+// @beta
+export const getPresence: (fluidContainer: IFluidContainer_2<ContainerSchema_2>) => Presence;
+
+// @alpha
+export const getPresenceAlpha: typeof getPresenceAlpha_2;
+
 // @alpha
 export function getSimpleSchema(schema: ImplicitFieldSchema): SimpleTreeSchema<SchemaType.View>;
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -518,7 +518,7 @@ export function getJsonSchema(schema: ImplicitAllowedTypes, options: Required<Tr
 export const getPresence: (fluidContainer: IFluidContainer_2<ContainerSchema_2>) => Presence;
 
 // @alpha
-export const getPresenceAlpha: typeof getPresenceAlpha_2;
+export const getPresenceAlpha: (fluidContainer: IFluidContainer_2) => PresenceWithNotifications;
 
 // @alpha
 export function getSimpleSchema(schema: ImplicitFieldSchema): SimpleTreeSchema<SchemaType.View>;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -138,12 +138,58 @@ export enum AttachState {
     Detached = "Detached"
 }
 
+// @beta @sealed
+export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
+    readonly attendeeId: SpecificAttendeeId;
+    getConnectionId(): ClientConnectionId;
+    getConnectionStatus(): AttendeeStatus;
+}
+
+// @beta
+export type AttendeeId = SessionId & {
+    readonly AttendeeId: "AttendeeId";
+};
+
+// @beta @sealed
+export interface AttendeesEvents {
+    // @eventProperty
+    attendeeConnected: (attendee: Attendee) => void;
+    // @eventProperty
+    attendeeDisconnected: (attendee: Attendee) => void;
+}
+
+// @beta
+export const AttendeeStatus: {
+    readonly Connected: "Connected";
+    readonly Disconnected: "Disconnected";
+};
+
+// @beta
+export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
+
 // @alpha @sealed
 export interface BranchableTree extends ViewableTree {
     branch(): TreeBranchFork;
     merge(branch: TreeBranchFork): void;
     merge(branch: TreeBranchFork, disposeMerged: boolean): void;
     rebase(branch: TreeBranchFork): void;
+}
+
+// @beta
+export class BrandedType<out Brand> {
+    static [Symbol.hasInstance](value: never): value is never;
+    protected constructor();
+    protected readonly brand: (dummy: never) => Brand;
+}
+
+// @beta @sealed
+export interface BroadcastControls {
+    allowableUpdateLatencyMs: number | undefined;
+}
+
+// @beta
+export interface BroadcastControlSettings {
+    readonly allowableUpdateLatencyMs?: number;
 }
 
 // @alpha @sealed
@@ -154,6 +200,9 @@ export function checkCompatibility(viewWhichCreatedStoredSchema: TreeViewConfigu
 
 // @alpha
 export function checkSchemaCompatibilitySnapshots(options: SchemaCompatibilitySnapshotsOptions): void;
+
+// @beta
+export type ClientConnectionId = string;
 
 // @alpha
 export function cloneWithReplacements(root: unknown, rootKey: string, replacer: (key: string, value: unknown) => {
@@ -274,6 +323,28 @@ export function createSimpleTreeIndex<TFieldSchema extends ImplicitFieldSchema, 
 
 // @alpha
 export function decodeSchemaCompatibilitySnapshot(encodedSchema: JsonCompatibleReadOnly, validator?: FormatValidator): SimpleTreeSchema;
+
+// @beta
+export type DeepReadonly<T, Options extends DeepReadonlyOptions = {
+    DeepenedGenerics: DeepReadonlySupportedGenericsDefault;
+    RecurseLimit: "NoLimit";
+}> = InternalCoreInterfacesUtilityTypes.DeepReadonlyImpl<T, Options extends {
+    DeepenedGenerics: unknown;
+} ? Options["DeepenedGenerics"] : DeepReadonlySupportedGenericsDefault, Options extends {
+    RecurseLimit: DeepReadonlyRecursionLimit;
+} ? Options["RecurseLimit"] : "NoLimit">;
+
+// @beta
+export interface DeepReadonlyOptions {
+    DeepenedGenerics?: ReadonlySupportedGenerics;
+    RecurseLimit?: DeepReadonlyRecursionLimit;
+}
+
+// @beta @system
+export type DeepReadonlyRecursionLimit = "NoLimit" | 0 | `+${string}`;
+
+// @beta @system
+export type DeepReadonlySupportedGenericsDefault = Map<unknown, unknown> | Promise<unknown> | Set<unknown> | WeakMap<object, unknown> | WeakSet<object>;
 
 // @public @sealed @system
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
@@ -515,10 +586,10 @@ export function getBranch<T extends ImplicitFieldSchema | UnsafeUnknownSchema>(v
 export function getJsonSchema(schema: ImplicitAllowedTypes, options: Required<TreeSchemaEncodingOptions>): JsonTreeSchema;
 
 // @beta
-export const getPresence: (fluidContainer: IFluidContainer_2<ContainerSchema_2>) => Presence;
+export const getPresence: (fluidContainer: IFluidContainer<ContainerSchema_2>) => Presence_2;
 
 // @alpha
-export const getPresenceAlpha: (fluidContainer: IFluidContainer_2) => PresenceWithNotifications;
+export const getPresenceAlpha: (fluidContainer: IFluidContainer) => PresenceWithNotifications;
 
 // @alpha
 export function getSimpleSchema(schema: ImplicitFieldSchema): SimpleTreeSchema<SchemaType.View>;
@@ -864,6 +935,398 @@ TSchema
 // @public
 export type InsertableTypedNode<TSchema extends TreeNodeSchema, T = UnionToIntersection<TSchema>> = (T extends TreeNodeSchema<string, NodeKind, TreeNode | TreeLeafValue, never, true> ? NodeBuilderData<T> : never) | (T extends TreeNodeSchema ? Unhydrated<TreeNode extends NodeFromSchema<T> ? never : NodeFromSchema<T>> : never);
 
+// @beta @system
+export namespace InternalCoreInterfacesUtilityTypes {
+    // @system
+    export type AnyOpaqueJsonType = OpaqueJsonSerializable<unknown, any, unknown> | OpaqueJsonDeserialized<unknown, any, unknown>;
+    // @system
+    export type AnyRecord = Record<keyof any, any>;
+    // @system
+    export type DeepenReadonlyInFluidHandleIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Readonly<IFluidHandle<infer V>> ? IFluidHandle<V> extends DeepenedGenerics ? Readonly<IFluidHandle<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>>> : Readonly<T> : Else;
+    // @system
+    export type DeepenReadonlyInGenerics<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = DeepenReadonlyInMapIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInSetIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInWeakMapIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInWeakSetIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInPromiseIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInFluidHandleIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, Else>>>>>>;
+    // @system
+    export type DeepenReadonlyInMapIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends ReadonlyMap<infer K, infer V> ? Map<K, V> extends DeepenedGenerics ? ReadonlyMap<ReadonlyImpl<K, DeepenedGenerics, NoDepthOrRecurseLimit>, ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>> : ReadonlyMap<K, V> : Else;
+    // @system
+    export type DeepenReadonlyInPromiseIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Promise<infer V> ? Promise<V> extends DeepenedGenerics ? Promise<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>> : T : Else;
+    // @system
+    export type DeepenReadonlyInSetIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends ReadonlySet<infer V> ? Set<V> extends DeepenedGenerics ? ReadonlySet<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>> : ReadonlySet<V> : Else;
+    // @system
+    export type DeepenReadonlyInWeakMapIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Omit<WeakMap<infer K, infer V>, "delete" | "set"> ? WeakMap<K, V> extends DeepenedGenerics ? Omit<WeakMap<ReadonlyImpl<K, DeepenedGenerics, NoDepthOrRecurseLimit>, ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>>, "delete" | "set"> : Omit<WeakMap<K, V>, "delete" | "set"> : Else;
+    // @system
+    export type DeepenReadonlyInWeakSetIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Omit<WeakSet<infer V>, "add" | "delete"> ? WeakSet<V> extends DeepenedGenerics ? Omit<WeakSet<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>>, "add" | "delete"> : Omit<WeakSet<V>, "add" | "delete"> : Else;
+    // @system
+    export type DeepReadonlyImpl<T, DeepenedGenerics extends ReadonlySupportedGenerics, RecurseLimit extends DeepReadonlyRecursionLimit> = ReadonlyImpl<T, DeepenedGenerics, RecurseLimit>;
+    // @system
+    export type DeepReadonlyLimitingRecursion<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends RecursionLimit> = ReplaceRecursionWithMarkerAndPreserveAllowances<T, RecursionMarker, {
+        AllowExactly: [];
+        AllowExtensionOf: never;
+    }> extends infer TNoRecursionAndOnlyPublics ? IsSameType<TNoRecursionAndOnlyPublics, DeepReadonlyWorker<TNoRecursionAndOnlyPublics, DeepenedGenerics, 0>> extends true ? IfNonPublicProperties<T, {
+        AllowExactly: [];
+        AllowExtensionOf: never;
+    }, "found non-publics", "only publics"> extends "found non-publics" ? DeepReadonlyWorker<T, DeepenedGenerics, Extract<NoDepthOrRecurseLimit, RecursionLimit>> : T : DeepReadonlyWorker<T, DeepenedGenerics, Extract<NoDepthOrRecurseLimit, RecursionLimit>> : never;
+    // @system
+    export type DeepReadonlyRecursingInfinitely<T, DeepenedGenerics extends ReadonlySupportedGenerics> = T extends object ? FilterPreservingFunction<T, T extends readonly ReadonlyJsonTypeWith<infer Alternates>[] ? true extends IfExactTypeInTuple<T, [
+    JsonTypeWith<Alternates>[],
+    readonly ReadonlyJsonTypeWith<Alternates>[]
+    ]> ? readonly ReadonlyJsonTypeWith<DeepReadonlyRecursingInfinitely<Alternates, DeepenedGenerics>>[] : {
+        readonly [K in keyof T]: DeepReadonlyRecursingInfinitely<T[K], DeepenedGenerics>;
+    } : DeepenReadonlyInGenerics<T, DeepenedGenerics, "NoLimit", PreserveErasedTypeOrBrandedPrimitive<T, {
+        readonly [K in keyof T]: DeepReadonlyRecursingInfinitely<T[K], DeepenedGenerics>;
+    }>>> : T;
+    // @system
+    export type DeepReadonlyRecursion<T, DeepenedGenerics extends ReadonlySupportedGenerics, RecurseLimit extends RecursionLimit, TAncestorTypes = T> = T extends TAncestorTypes ? RecurseLimit extends `+${infer RecursionRemainder}` ? DeepReadonlyLimitingRecursion<T, DeepenedGenerics, RecursionRemainder extends RecursionLimit ? RecursionRemainder : 0> : T : DeepReadonlyWorker<T, DeepenedGenerics, RecurseLimit, TAncestorTypes | T>;
+    // @system
+    export type DeepReadonlyWorker<T, DeepenedGenerics extends ReadonlySupportedGenerics, RecurseLimit extends RecursionLimit, TAncestorTypes = T> = T extends object ? FilterPreservingFunction<T, DeepenReadonlyInGenerics<T, DeepenedGenerics, RecurseLimit, PreserveErasedTypeOrBrandedPrimitive<T, {
+        readonly [K in keyof T]: DeepReadonlyRecursion<T[K], DeepenedGenerics, RecurseLimit, TAncestorTypes>;
+    }>>> : T;
+    // @system
+    export interface DeserializedFilterControls extends FilterControlsWithSubstitution {
+        DegenerateNonNullObjectSubstitute: unknown;
+        RecursionMarkerAllowed: unknown;
+    }
+    // @system
+    export type ExcludeExactly<T, U> = IfSameType<T, U, never, T>;
+    // @system
+    export type ExcludeExactlyInTuple<T, TupleOfU extends unknown[]> = IfExactTypeInTuple<T, TupleOfU, never, T>;
+    // @system
+    export type ExtractFunctionFromIntersection<T extends object> = (T extends new (...args: infer A) => infer R ? new (...args: A) => R : unknown) & (T extends (...args: infer A) => infer R ? (...args: A) => R : unknown) extends infer Functional ? {
+        classification: unknown extends Functional ? "no Function" : Functional extends Required<T> ? "exactly Function" : "Function and more";
+        function: Functional;
+    } : never;
+    // @system
+    export interface FilterControls {
+        AllowExactly: unknown[];
+        AllowExtensionOf: unknown;
+    }
+    // @system
+    export interface FilterControlsWithSubstitution extends FilterControls {
+        DegenerateSubstitute: unknown;
+    }
+    // @system
+    export type FilterPreservingFunction<Original extends object, Filtered> = ExtractFunctionFromIntersection<Original> extends {
+        classification: infer TClassification;
+        function: infer TFunction;
+    } ? TClassification extends "exactly Function" ? TFunction : TFunction & Filtered : never;
+    // @system
+    export type FlattenIntersection<T extends AnyRecord> = T extends AnyRecord ? {
+        [K in keyof T]: T[K];
+    } : T;
+    // @system
+    export type IfEnumLike<T extends object, EnumLike = never, NotEnumLike = unknown> = T extends readonly (infer _)[] ? NotEnumLike : T extends Function ? NotEnumLike : T extends {
+        readonly [i: number]: string;
+        readonly [p: string]: number | string;
+        readonly [s: symbol]: never;
+    } ? true extends {
+        [K in keyof T]: T[K] extends never ? true : never;
+    }[keyof T] ? NotEnumLike : EnumLike : NotEnumLike;
+    export type IfExactTypeInTuple<T, Tuple extends unknown[], IfMatch = unknown, IfNoMatch = never> = Tuple extends [infer First, ...infer Rest] ? IfSameType<T, First, IfMatch, IfExactTypeInTuple<T, Rest, IfMatch, IfNoMatch>> : IfNoMatch;
+    // @system
+    export type IfExactTypeInUnion<T, Union, IfMatch = unknown, IfNoMatch = never> = IfSameType<T, never, IfSameType<Union, never, IfMatch, IfNoMatch>, IfSameType<T, Extract<Union, T>, IfMatch, IfNoMatch>>;
+    // @system
+    export type IfIndexOrBrandedKey<T extends keyof AnyRecord, IfIndexOrBranded, Otherwise> = T extends object ? IfIndexOrBranded : IfVariableStringOrNumber<T, IfIndexOrBranded, Otherwise>;
+    // @system
+    export type IfNonPublicProperties<T, Controls extends FilterControls, HasNonPublic = never, OnlyPublics = unknown> = ReplaceAllowancesAndRecursionWithNever<T, Controls> extends T ? OnlyPublics : HasNonPublic;
+    // @system
+    export type IfPossiblyUndefinedProperty<TKey extends keyof AnyRecord, TValue, Result extends {
+        IfPossiblyUndefined: unknown;
+        IfUnknownNonIndexed: unknown;
+        Otherwise: unknown;
+    }> = undefined extends TValue ? unknown extends TValue ? IfIndexOrBrandedKey<TKey, Result["Otherwise"], Result["IfUnknownNonIndexed"]> : Result["IfPossiblyUndefined"] : Result["Otherwise"];
+    // @system
+    export type IfSameType<X, Y, IfSame = unknown, IfDifferent = never> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? IfSame : IfDifferent;
+    // @system
+    export type IfVariableStringOrNumber<T, IfVariable, IfLiteral> = `${string}` extends T ? IfVariable : number extends T ? IfVariable : T extends `${infer first}${infer rest}` ? string extends first ? IfVariable : `${number}` extends first ? IfVariable : IfVariableStringOrNumber<rest, IfVariable, IfLiteral> : IfLiteral;
+    // @system
+    export type IsExactlyObject<T extends object> = IsSameType<T, object>;
+    // @system
+    export type IsSameType<X, Y> = IfSameType<X, Y, true, false>;
+    // @system
+    export type JsonDeserializedFilter<T, Controls extends DeserializedFilterControls, TAncestorTypes extends object[] = [Extract<T, object>]> = boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : unknown extends T ? Controls["DegenerateSubstitute"] : T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, [
+    ...Controls["AllowExactly"],
+    Controls["RecursionMarkerAllowed"]
+    ], true, "not found"> extends true ? T : T extends object ? ExtractFunctionFromIntersection<T> extends {
+        classification: "exactly Function";
+    } ? never : T extends readonly (infer _)[] ? {
+        [K in keyof T]: JsonForDeserializedArrayItem<T[K], Controls, JsonDeserializedRecursion<T[K], Controls, TAncestorTypes>>;
+    } : IsExactlyObject<T> extends true ? Controls["DegenerateNonNullObjectSubstitute"] : IfEnumLike<T> extends never ? T : T extends AnyOpaqueJsonType ? JsonDeserializedOpaqueConversion<T, Controls> : FlattenIntersection<{
+        [K in keyof T as NonSymbolWithDeserializablePropertyOf<T, [
+        ...Controls["AllowExactly"],
+        Controls["RecursionMarkerAllowed"]
+        ], Controls["AllowExtensionOf"], K>]: JsonDeserializedRecursion<T[K], Controls, TAncestorTypes>;
+    } & {
+        [K in keyof T as NonSymbolLiteralWithPossiblyDeserializablePropertyOf<T, [
+        ...Controls["AllowExactly"],
+        Controls["RecursionMarkerAllowed"]
+        ], Controls["AllowExtensionOf"], K>]?: JsonDeserializedRecursion<T[K], Controls, TAncestorTypes>;
+    }> : never;
+    // @system
+    export type JsonDeserializedImpl<T, Options extends Partial<FilterControls>, TypeUnderRecursion extends boolean = false> = {
+        AllowExactly: Options extends {
+            AllowExactly: unknown[];
+        } ? Options["AllowExactly"] : [];
+        AllowExtensionOf: Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never;
+        DegenerateSubstitute: JsonTypeWith<(Options extends {
+            AllowExactly: unknown[];
+        } ? TupleToUnion<Options["AllowExactly"]> : never) | (Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never)>;
+        DegenerateNonNullObjectSubstitute: NonNullJsonObjectWith<(Options extends {
+            AllowExactly: unknown[];
+        } ? TupleToUnion<Options["AllowExactly"]> : never) | (Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never)>;
+        RecursionMarkerAllowed: never;
+    } extends infer Controls ? Controls extends DeserializedFilterControls ? boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : ReplaceRecursionWithMarkerAndPreserveAllowances<T, RecursionMarker, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"] | AnyOpaqueJsonType;
+    }> extends infer TNoRecursionAndOnlyPublics ? IsSameType<TNoRecursionAndOnlyPublics, JsonDeserializedFilter<TNoRecursionAndOnlyPublics, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"];
+        DegenerateSubstitute: Controls["DegenerateSubstitute"];
+        DegenerateNonNullObjectSubstitute: Controls["DegenerateNonNullObjectSubstitute"];
+        RecursionMarkerAllowed: RecursionMarker;
+    }>> extends true ? IfNonPublicProperties<T, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"] | AnyOpaqueJsonType;
+    }, "found non-publics", "only publics"> extends "found non-publics" ? TypeUnderRecursion extends false ? JsonDeserializedFilter<T, Controls> : OpaqueJsonDeserialized<T, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : T : TypeUnderRecursion extends false ? JsonDeserializedFilter<T, Controls> : OpaqueJsonDeserialized<T, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : never : never : never;
+    // @system
+    export type JsonDeserializedOpaqueConversion<T extends AnyOpaqueJsonType, Controls extends FilterControls> = T extends OpaqueJsonSerializable<infer TData, any, unknown> | OpaqueJsonDeserialized<infer TData, any, unknown> ? OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : "internal error: failed to determine OpaqueJson* type";
+    // @system
+    export type JsonDeserializedRecursion<T, Controls extends DeserializedFilterControls, TAncestorTypes extends object[]> = IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? JsonDeserializedImpl<T, Controls, true> : T extends object ? IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? JsonDeserializedImpl<T, Controls, true> : JsonDeserializedFilter<T, Controls, [
+    ...TAncestorTypes,
+    T
+    ]> : JsonDeserializedFilter<T, Controls, TAncestorTypes>;
+    // @system
+    export type JsonForDeserializedArrayItem<T, Controls extends DeserializedFilterControls, TBlessed> = boolean extends (T extends never ? true : false) ? TBlessed : unknown extends T ? TBlessed : T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, [
+    ...Controls["AllowExactly"],
+    Controls["RecursionMarkerAllowed"]
+    ], T, T extends undefined | symbol ? null : T extends Function ? ExtractFunctionFromIntersection<T> extends {
+        classification: "exactly Function";
+    } ? null : null | TBlessed : TBlessed>;
+    // @system
+    export type JsonForSerializableArrayItem<T, Controls extends FilterControls, TAncestorTypes extends unknown[], TBlessed> = boolean extends (T extends never ? true : false) ? TBlessed : unknown extends T ? TBlessed : IfExactTypeInTuple<T, TAncestorTypes, T, T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, Controls["AllowExactly"], T, undefined extends T ? SerializationErrorPerUndefinedArrayElement : TBlessed>>;
+    // @system
+    export type JsonSerializableFilter<T, Controls extends FilterControlsWithSubstitution, TAncestorTypes extends unknown[], TNextAncestor = T> = boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : unknown extends T ? Controls["DegenerateSubstitute"] : IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? T : T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, Controls["AllowExactly"], true, "no match"> extends true ? T : Extract<T, Function> extends never ? T extends object ? T extends readonly (infer _)[] ? {
+        [K in keyof T]: JsonForSerializableArrayItem<T[K], Controls, TAncestorTypes, JsonSerializableFilter<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>>;
+    } : IsExactlyObject<T> extends true ? NonNullJsonObjectWith<TupleToUnion<Controls["AllowExactly"]> | Controls["AllowExtensionOf"]> : IfEnumLike<T> extends never ? T : T extends AnyOpaqueJsonType ? JsonSerializableOpaqueAllowances<T, Controls> : FlattenIntersection<{
+        [K in keyof T as RequiredNonSymbolKeysOf<T, K>]-?: IfPossiblyUndefinedProperty<K, T[K], {
+            IfPossiblyUndefined: {
+                ["error required property may not allow `undefined` value"]: never;
+            };
+            IfUnknownNonIndexed: {
+                ["error required property may not allow `unknown` value"]: never;
+            };
+            Otherwise: JsonSerializableFilter<T[K], Controls, [
+            TNextAncestor,
+            ...TAncestorTypes
+            ]>;
+        }>;
+    } & {
+        [K in keyof T as OptionalNonSymbolKeysOf<T, K>]?: JsonSerializableFilter<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    } & {
+        [K in keyof T & symbol]: never;
+    }> : never : never;
+    // @system
+    export type JsonSerializableImpl<T, Options extends Partial<FilterControls> & {
+        IgnoreInaccessibleMembers?: "ignore-inaccessible-members";
+    }, TAncestorTypes extends unknown[] = [], TNextAncestor = T> = {
+        AllowExactly: Options extends {
+            AllowExactly: unknown[];
+        } ? Options["AllowExactly"] : [];
+        AllowExtensionOf: Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never;
+        DegenerateSubstitute: JsonTypeWith<(Options extends {
+            AllowExactly: unknown[];
+        } ? TupleToUnion<Options["AllowExactly"]> : never) | (Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never)> | OpaqueJsonSerializable<unknown, Options extends {
+            AllowExactly: unknown[];
+        } ? Options["AllowExactly"] : [], Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never>;
+    } extends infer Controls ? Controls extends FilterControlsWithSubstitution ? boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : Options extends {
+        IgnoreInaccessibleMembers: "ignore-inaccessible-members";
+    } ? JsonSerializableFilter<T, Controls, TAncestorTypes, TNextAncestor> : IfNonPublicProperties<T, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"] | boolean | number | string | AnyOpaqueJsonType;
+    }, "found non-publics", "only publics"> extends "found non-publics" ? T extends readonly (infer _)[] ? {
+        [K in keyof T]: JsonSerializableImpl<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    } : T extends boolean | number | string ? T : SerializationErrorPerNonPublicProperties : JsonSerializableFilter<T, Controls, TAncestorTypes, TNextAncestor> : never : never;
+    // @system
+    export type JsonSerializableOpaqueAllowances<T extends AnyOpaqueJsonType, Controls extends FilterControlsWithSubstitution> = T extends OpaqueJsonSerializable<infer TData, any, unknown> | OpaqueJsonDeserialized<infer TData, any, unknown> ? T extends OpaqueJsonSerializable<TData, any, unknown> & OpaqueJsonDeserialized<TData, any, unknown> ? OpaqueJsonSerializable<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> & OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : T extends OpaqueJsonSerializable<TData, any, unknown> ? OpaqueJsonSerializable<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : T extends OpaqueJsonDeserialized<TData, any, unknown> ? OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : "internal error: failed to determine OpaqueJson* type" : never;
+    // @system
+    export type NonSymbolLiteralWithPossiblyDeserializablePropertyOf<T extends object, TExactExceptions extends unknown[], TExtendsException, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: IfIndexOrBrandedKey<K, never, ExcludeExactlyInTuple<Exclude<T[K], TExtendsException>, OmitExactlyFromTuple<TExactExceptions, unknown>> extends infer PossibleTypeLessAllowed ? Extract<IfSameType<PossibleTypeLessAllowed, unknown, undefined, PossibleTypeLessAllowed>, undefined | symbol | Function> extends never ? never : TestDeserializabilityOf<T[K], OmitExactlyFromTuple<TExactExceptions, unknown>, TExtendsException, {
+            WhenSomethingDeserializable: K;
+            WhenNeverDeserializable: never;
+        }> : never>;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type NonSymbolWithDeserializablePropertyOf<T extends object, TExactExceptions extends unknown[], TExtendsException, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: ExcludeExactlyInTuple<Exclude<T[K], TExtendsException>, OmitExactlyFromTuple<TExactExceptions, unknown>> extends infer PossibleTypeLessAllowed ? IfSameType<PossibleTypeLessAllowed, unknown, IfIndexOrBrandedKey<K, K, never>, Extract<PossibleTypeLessAllowed, undefined | symbol | Function> extends never ? IfSameType<PossibleTypeLessAllowed, bigint, never, T[K] extends never ? never : K> : TestDeserializabilityOf<T[K], OmitExactlyFromTuple<TExactExceptions, unknown>, TExtendsException, {
+            WhenSomethingDeserializable: IfIndexOrBrandedKey<K, K, never>;
+            WhenNeverDeserializable: never;
+        }>> : never;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type OmitExactlyFromTuple<Tuple extends unknown[], U, Accumulated extends unknown[] = []> = Tuple extends [infer First, ...infer Rest] ? OmitExactlyFromTuple<Rest, U, IfSameType<First, U, Accumulated, [...Accumulated, First]>> : Accumulated;
+    // @system
+    export type OmitFromTuple<Tuple extends unknown[], U, Accumulated extends unknown[] = []> = Tuple extends [infer First, ...infer Rest] ? OmitFromTuple<Rest, U, First extends U ? Accumulated : [...Accumulated, First]> : Accumulated;
+    // @system
+    export type OptionalNonSymbolKeysOf<T extends object, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: T extends Record<K, T[K]> ? never : K;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type PreserveErasedTypeOrBrandedPrimitive<T extends object, Else> = T extends ErasedType<infer _> ? T : T extends infer Brand & (boolean | number | string | symbol | bigint) ? T extends Brand & infer Primitive ? /* [potentially] branded type => "as-is" */ Primitive & Brand : T : Else;
+    // @system
+    export type ReadonlyImpl<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit> = NoDepthOrRecurseLimit extends "Shallow" ? ShallowReadonlyImpl<T, DeepenedGenerics> : NoDepthOrRecurseLimit extends "NoLimit" ? DeepReadonlyRecursingInfinitely<T, DeepenedGenerics> : DeepReadonlyLimitingRecursion<T, DeepenedGenerics, Extract<NoDepthOrRecurseLimit, RecursionLimit>>;
+    // @system
+    export type RecursionLimit = `+${string}` | 0;
+    // @system
+    export interface RecursionMarker {
+        // (undocumented)
+        [RecursionMarkerSymbol]: typeof RecursionMarkerSymbol;
+    }
+    // @system
+    export type ReplaceAllowancesAndRecursionWithNever<T, Controls extends FilterControls, TAncestorTypes extends unknown[] = [], TNextAncestor = T> = IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? never : T extends Controls["AllowExtensionOf"] ? never : IfExactTypeInTuple<T, Controls["AllowExactly"], true, "no match"> extends true ? never : IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? never : T extends object ? FilterPreservingFunction<T, {
+        [K in keyof T]: ReplaceAllowancesAndRecursionWithNever<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    }> : T;
+    // @system
+    export type ReplaceRecursionWithMarkerAndPreserveAllowances<T, TRecursionMarker, Controls extends FilterControls, TAncestorTypes extends unknown[] = [], TNextAncestor = T> = IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? TRecursionMarker : T extends infer _ ? IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? TRecursionMarker : T extends Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, Controls["AllowExactly"], true, "no match"> extends true ? T : T extends object ? FilterPreservingFunction<T, {
+        [K in keyof T]: ReplaceRecursionWithMarkerAndPreserveAllowances<T[K], TRecursionMarker, Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    }> : T : never;
+    // @system
+    export type RequiredNonSymbolKeysOf<T extends object, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: T extends Record<K, T[K]> ? K : never;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type ShallowReadonlyImpl<T, DeepenedGenerics extends ReadonlySupportedGenerics> = T extends object ? FilterPreservingFunction<T, DeepenReadonlyInGenerics<T, DeepenedGenerics, "Shallow", PreserveErasedTypeOrBrandedPrimitive<T, /* basic type => */ Readonly<T>>>> : T;
+    // @system
+    export type TestDeserializabilityOf<T, TExactExceptions extends unknown[], TExtendsException, Result extends {
+        WhenSomethingDeserializable: unknown;
+        WhenNeverDeserializable: never;
+    } | {
+        WhenSomethingDeserializable: never;
+        WhenNeverDeserializable: unknown;
+    }> = T extends never ? Result["WhenNeverDeserializable"] : T extends TExtendsException ? Result["WhenSomethingDeserializable"] : IfExactTypeInTuple<T, TExactExceptions, Result["WhenSomethingDeserializable"], T extends bigint | symbol | undefined ? Result["WhenNeverDeserializable"] : T extends Function ? ExtractFunctionFromIntersection<T> extends {
+        classification: "exactly Function";
+    } ? Result["WhenNeverDeserializable"] : Result["WhenSomethingDeserializable"] : Result["WhenSomethingDeserializable"]>;
+    // @system
+    export type TupleToUnion<T extends unknown[]> = T[number];
+        {};
+}
+
+// @beta @system
+export namespace InternalPresenceTypes {
+    // @system
+    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
+        instanceBase: new (...args: any[]) => unknown;
+    } & ((key: TKey, datastoreHandle: StateDatastoreHandle<TKey, TValue>) => {
+        initialData?: {
+            value: TValue;
+            allowableUpdateLatencyMs: number | undefined;
+        };
+        manager: StateValue<TManager>;
+    });
+    // @system
+    export interface MapValueState<T, Keys extends string> {
+        // (undocumented)
+        items: {
+            [name in Keys]: ValueOptionalState<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export interface NotificationType {
+        // (undocumented)
+        args: unknown[];
+        // (undocumented)
+        name: string;
+    }
+    // @system
+    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<unknown>> {
+    }
+    // @system
+    export type StateValue<T> = T & StateValueBrand<T>;
+    // @system
+    export class StateValueBrand<T> {
+    }
+    // @system
+    export interface ValueDirectory<T> {
+        // (undocumented)
+        items: {
+            [name: string | number]: ValueOptionalState<T> | ValueDirectory<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export type ValueDirectoryOrState<T> = ValueRequiredState<T> | ValueDirectory<T>;
+    // @system
+    export interface ValueOptionalState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value?: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueRequiredState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueStateMetadata {
+        // (undocumented)
+        rev: number;
+        // (undocumented)
+        timestamp: number;
+    }
+}
+
+// @alpha @system
+export namespace InternalPresenceUtilityTypes {
+    // @system
+    export type IfNotificationParametersSignature<Event, IfParametersValid, Else> = Event extends (...args: infer P) => void ? InternalCoreInterfacesUtilityTypes.IfSameType<P, JsonSerializable<P>, IfParametersValid, Else> : Else;
+    // @system
+    export type IfNotificationSubscriberSignature<Event, IfSubscriber, Else> = Event extends (sender: Attendee, ...args: infer P) => void ? InternalCoreInterfacesUtilityTypes.IfSameType<P, JsonSerializable<P>, IfSubscriber, Else> : Else;
+    // @system
+    export type JsonDeserializedParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonDeserialized<P> : never;
+    // @system
+    export type JsonSerializableParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonSerializable<P> : never;
+    // @system
+    export type NotificationListeners<E> = {
+        [P in keyof E as IfNotificationParametersSignature<E[P], P, never>]: E[P];
+    };
+    // @system
+    export type NotificationListenersFromSubscriberSignatures<E extends NotificationListenersWithSubscriberSignatures<E>> = {
+        [K in keyof NotificationListenersWithSubscriberSignatures<E>]: NotificationParametersSignatureFromSubscriberSignature<E[K]>;
+    } extends infer TListeners ? NotificationListeners<TListeners> : never;
+    // @system
+    export type NotificationListenersWithSubscriberSignatures<E> = {
+        [P in keyof E as IfNotificationSubscriberSignature<E[P], P, never>]: E[P];
+    };
+    // @system
+    export type NotificationParametersSignatureFromSubscriberSignature<Event> = Event extends (sender: Attendee, ...args: infer P) => void ? (...args: P) => void : never;
+}
+
 // @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
@@ -995,6 +1458,18 @@ export type JsonCompatibleReadOnlyObject = {
     readonly [P in string]?: JsonCompatibleReadOnly;
 };
 
+// @beta
+export type JsonDeserialized<T, Options extends JsonDeserializedOptions = {
+    AllowExactly: [];
+    AllowExtensionOf: never;
+}> = InternalCoreInterfacesUtilityTypes.JsonDeserializedImpl<T, Options>;
+
+// @beta
+export interface JsonDeserializedOptions {
+    AllowExactly?: unknown[];
+    AllowExtensionOf?: unknown;
+}
+
 // @alpha @sealed
 export type JsonFieldSchema = {
     readonly description?: string | undefined;
@@ -1051,6 +1526,19 @@ export interface JsonSchemaRef {
 // @alpha
 export type JsonSchemaType = "object" | "array" | JsonLeafSchemaType;
 
+// @beta
+export type JsonSerializable<T, Options extends JsonSerializableOptions = {
+    AllowExactly: [];
+    AllowExtensionOf: never;
+}> = InternalCoreInterfacesUtilityTypes.JsonSerializableImpl<T, Options>;
+
+// @beta
+export interface JsonSerializableOptions {
+    AllowExactly?: unknown[];
+    AllowExtensionOf?: unknown;
+    IgnoreInaccessibleMembers?: "ignore-inaccessible-members";
+}
+
 // @alpha @sealed
 export interface JsonStringKeyPatternProperties {
     "^.*$": JsonFieldSchema;
@@ -1060,6 +1548,11 @@ export interface JsonStringKeyPatternProperties {
 export type JsonTreeSchema = JsonFieldSchema & {
     readonly $defs: Record<JsonSchemaId, JsonNodeSchema>;
 };
+
+// @beta
+export type JsonTypeWith<T> = null | boolean | number | string | T | {
+    [key: string | number]: JsonTypeWith<T>;
+} | JsonTypeWith<T>[];
 
 // @beta @input
 export enum KeyEncodingOptions {
@@ -1186,8 +1679,52 @@ export interface NodeSchemaOptionsAlpha<out TCustomMetadata = unknown> extends N
     readonly persistedMetadata?: JsonCompatibleReadOnlyObject | undefined;
 }
 
+// @beta
+export type NonNullJsonObjectWith<T> = {
+    [key: string | number]: JsonTypeWith<T>;
+} | JsonTypeWith<T>[];
+
 // @alpha
 export function normalizeAllowedTypes(types: ImplicitAllowedTypes): AllowedTypesFull;
+
+// @alpha @sealed
+export interface NotificationEmitter<E extends InternalPresenceUtilityTypes.NotificationListeners<E>> {
+    broadcast<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<E>>(notificationName: K, ...args: Parameters<E[K]>): void;
+    unicast<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<E>>(notificationName: K, targetAttendee: Attendee, ...args: Parameters<E[K]>): void;
+}
+
+// @alpha @sealed
+export interface NotificationListenable<TListeners extends InternalPresenceUtilityTypes.NotificationListeners<TListeners>> {
+    off<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): void;
+    on<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): Off;
+}
+
+// @alpha @sealed
+export interface NotificationsManager<T extends InternalPresenceUtilityTypes.NotificationListeners<T>> {
+    readonly emit: NotificationEmitter<T>;
+    readonly events: Listenable<NotificationsManagerEvents>;
+    readonly notifications: NotificationListenable<T>;
+    readonly presence: PresenceWithNotifications;
+}
+
+// @alpha @sealed (undocumented)
+export interface NotificationsManagerEvents {
+    // @eventProperty
+    unattendedNotification: (name: string, sender: Attendee, ...content: unknown[]) => void;
+}
+
+// @alpha @sealed
+export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>>;
+    readonly notifications: StatesWorkspaceEntries<TSchema>;
+    readonly presence: PresenceWithNotifications;
+}
+
+// @alpha
+export interface NotificationsWorkspaceSchema {
+    // (undocumented)
+    [key: string]: InternalPresenceTypes.ManagerFactory<typeof key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
+}
 
 // @public @system
 export type NumberKeys<T, Transformed = {
@@ -1230,11 +1767,66 @@ export type Off = () => void;
 // @alpha
 export function onAssertionFailure(handler: (error: Error) => void): () => void;
 
+// @beta @sealed
+export class OpaqueJsonDeserialized<T, in out Option_AllowExactly extends unknown[] = [], out Option_AllowExtensionOf = never> extends BrandedType<"JsonDeserialized"> {
+    // (undocumented)
+    protected readonly JsonDeserialized: {
+        Type: T;
+        Options: {
+            AllowExactly: Option_AllowExactly;
+            AllowExtensionOf: Option_AllowExtensionOf;
+        };
+    };
+    // (undocumented)
+    protected readonly Option_AllowExactly_Invariance: (Option_AllowExactly: Option_AllowExactly) => void;
+}
+
+// @beta @sealed
+export class OpaqueJsonSerializable<T, in out Option_AllowExactly extends unknown[] = [], out Option_AllowExtensionOf = never> extends BrandedType<"JsonSerializable"> {
+    // (undocumented)
+    protected readonly JsonSerializable: {
+        Type: T;
+        Options: {
+            AllowExactly: Option_AllowExactly;
+            AllowExtensionOf: Option_AllowExtensionOf;
+        };
+    };
+    // (undocumented)
+    protected readonly Option_AllowExactly_Invariance: (Option_AllowExactly: Option_AllowExactly) => void;
+}
+
 // @alpha
 export function persistedToSimpleSchema(persisted: JsonCompatible, options: ICodecOptions): SimpleTreeSchema;
 
 // @beta @system
 export type PopUnion<Union, AsOverloadedFunction = UnionToIntersection<Union extends unknown ? (f: Union) => void : never>> = AsOverloadedFunction extends (a: infer First) => void ? First : never;
+
+// @beta @sealed
+export interface Presence {
+    readonly attendees: {
+        readonly events: Listenable<AttendeesEvents>;
+        getAttendees(): ReadonlySet<Attendee>;
+        getAttendee(clientId: ClientConnectionId | AttendeeId): Attendee;
+        getMyself(): Attendee;
+    };
+    readonly events: Listenable<PresenceEvents>;
+    readonly states: {
+        getWorkspace<StatesSchema extends StatesWorkspaceSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
+    };
+}
+
+// @beta @sealed
+export interface PresenceEvents {
+    workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
+}
+
+// @alpha @sealed
+export interface PresenceWithNotifications extends Presence {
+    // (undocumented)
+    readonly notifications: {
+        getWorkspace<NotificationsSchema extends NotificationsWorkspaceSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema>;
+    };
+}
 
 // @alpha @system
 export type ReadableField<TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema> = TreeFieldFromImplicitField<ReadSchema<TSchema>>;
@@ -1242,6 +1834,14 @@ export type ReadableField<TSchema extends ImplicitFieldSchema | UnsafeUnknownSch
 // @public @sealed @system
 export interface ReadonlyArrayNode<out T = TreeNode | TreeLeafValue> extends ReadonlyArray<T>, Awaited<TreeNode & WithType<string, NodeKind.Array>> {
 }
+
+// @beta
+export type ReadonlyJsonTypeWith<TReadonlyAlternates> = null | boolean | number | string | TReadonlyAlternates | {
+    readonly [key: string | number]: ReadonlyJsonTypeWith<TReadonlyAlternates>;
+} | readonly ReadonlyJsonTypeWith<TReadonlyAlternates>[];
+
+// @beta
+export type ReadonlySupportedGenerics = IFluidHandle | Map<unknown, unknown> | Promise<unknown> | Set<unknown> | WeakMap<object, unknown> | WeakSet<object>;
 
 // @alpha @system
 export type ReadSchema<TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema> = [
@@ -1492,6 +2092,16 @@ export class SchemaUpgrade {
 // @public @system
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
+// @beta @system
+export type SerializationErrorPerNonPublicProperties = {
+    "object serialization error": "non-public properties are not supported";
+};
+
+// @beta @system
+export type SerializationErrorPerUndefinedArrayElement = {
+    "array serialization error": "undefined elements are not supported";
+};
+
 // @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
@@ -1605,6 +2215,30 @@ export interface SnapshotFileSystem {
     writeFileSync(file: string, data: string, options: {
         encoding: "utf8";
     }): void;
+}
+
+// @beta @sealed
+export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    readonly controls: BroadcastControls;
+    readonly presence: Presence;
+    readonly states: StatesWorkspaceEntries<TSchema>;
+}
+
+// @beta @sealed
+export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
+    /**
+    * Registered State objects.
+    */
+    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
+};
+
+// @beta
+export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
+
+// @beta
+export interface StatesWorkspaceSchema {
+    [key: string]: StatesWorkspaceEntry<typeof key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
 }
 
 // @beta @system
@@ -2308,5 +2942,8 @@ export interface WithType<out TName extends string = string, out TKind extends N
     get [typeNameSymbol](): TName;
     get [typeSchemaSymbol](): TreeNodeSchemaClass<TName, TKind, TreeNode, never, boolean, TInfo>;
 }
+
+// @beta
+export type WorkspaceAddress = `${string}:${string}`;
 
 ```

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -589,9 +589,6 @@ export function getJsonSchema(schema: ImplicitAllowedTypes, options: Required<Tr
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @alpha
-export const getPresenceAlpha: (fluidContainer: IFluidContainer) => PresenceWithNotifications;
-
-// @alpha
 export function getSimpleSchema(schema: ImplicitFieldSchema): SimpleTreeSchema<SchemaType.View>;
 
 // @alpha
@@ -1301,32 +1298,6 @@ export namespace InternalPresenceTypes {
     }
 }
 
-// @alpha @system
-export namespace InternalPresenceUtilityTypes {
-    // @system
-    export type IfNotificationParametersSignature<Event, IfParametersValid, Else> = Event extends (...args: infer P) => void ? InternalCoreInterfacesUtilityTypes.IfSameType<P, JsonSerializable<P>, IfParametersValid, Else> : Else;
-    // @system
-    export type IfNotificationSubscriberSignature<Event, IfSubscriber, Else> = Event extends (sender: Attendee, ...args: infer P) => void ? InternalCoreInterfacesUtilityTypes.IfSameType<P, JsonSerializable<P>, IfSubscriber, Else> : Else;
-    // @system
-    export type JsonDeserializedParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonDeserialized<P> : never;
-    // @system
-    export type JsonSerializableParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonSerializable<P> : never;
-    // @system
-    export type NotificationListeners<E> = {
-        [P in keyof E as IfNotificationParametersSignature<E[P], P, never>]: E[P];
-    };
-    // @system
-    export type NotificationListenersFromSubscriberSignatures<E extends NotificationListenersWithSubscriberSignatures<E>> = {
-        [K in keyof NotificationListenersWithSubscriberSignatures<E>]: NotificationParametersSignatureFromSubscriberSignature<E[K]>;
-    } extends infer TListeners ? NotificationListeners<TListeners> : never;
-    // @system
-    export type NotificationListenersWithSubscriberSignatures<E> = {
-        [P in keyof E as IfNotificationSubscriberSignature<E[P], P, never>]: E[P];
-    };
-    // @system
-    export type NotificationParametersSignatureFromSubscriberSignature<Event> = Event extends (sender: Attendee, ...args: infer P) => void ? (...args: P) => void : never;
-}
-
 // @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
@@ -1687,45 +1658,6 @@ export type NonNullJsonObjectWith<T> = {
 // @alpha
 export function normalizeAllowedTypes(types: ImplicitAllowedTypes): AllowedTypesFull;
 
-// @alpha @sealed
-export interface NotificationEmitter<E extends InternalPresenceUtilityTypes.NotificationListeners<E>> {
-    broadcast<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<E>>(notificationName: K, ...args: Parameters<E[K]>): void;
-    unicast<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<E>>(notificationName: K, targetAttendee: Attendee, ...args: Parameters<E[K]>): void;
-}
-
-// @alpha @sealed
-export interface NotificationListenable<TListeners extends InternalPresenceUtilityTypes.NotificationListeners<TListeners>> {
-    off<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): void;
-    on<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): Off;
-}
-
-// @alpha @sealed
-export interface NotificationsManager<T extends InternalPresenceUtilityTypes.NotificationListeners<T>> {
-    readonly emit: NotificationEmitter<T>;
-    readonly events: Listenable<NotificationsManagerEvents>;
-    readonly notifications: NotificationListenable<T>;
-    readonly presence: PresenceWithNotifications;
-}
-
-// @alpha @sealed (undocumented)
-export interface NotificationsManagerEvents {
-    // @eventProperty
-    unattendedNotification: (name: string, sender: Attendee, ...content: unknown[]) => void;
-}
-
-// @alpha @sealed
-export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
-    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>>;
-    readonly notifications: StatesWorkspaceEntries<TSchema>;
-    readonly presence: PresenceWithNotifications;
-}
-
-// @alpha
-export interface NotificationsWorkspaceSchema {
-    // (undocumented)
-    [key: string]: InternalPresenceTypes.ManagerFactory<typeof key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
-}
-
 // @public @system
 export type NumberKeys<T, Transformed = {
     readonly [Property in keyof T as number extends Property ? never : Property]: Property;
@@ -1818,14 +1750,6 @@ export interface Presence {
 // @beta @sealed
 export interface PresenceEvents {
     workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
-}
-
-// @alpha @sealed
-export interface PresenceWithNotifications extends Presence {
-    // (undocumented)
-    readonly notifications: {
-        getWorkspace<NotificationsSchema extends NotificationsWorkspaceSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema>;
-    };
 }
 
 // @alpha @system

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -586,7 +586,7 @@ export function getBranch<T extends ImplicitFieldSchema | UnsafeUnknownSchema>(v
 export function getJsonSchema(schema: ImplicitAllowedTypes, options: Required<TreeSchemaEncodingOptions>): JsonTreeSchema;
 
 // @beta
-export const getPresence: (fluidContainer: IFluidContainer<ContainerSchema_2>) => Presence_2;
+export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @alpha
 export const getPresenceAlpha: (fluidContainer: IFluidContainer) => PresenceWithNotifications;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -291,6 +291,9 @@ export const ForestTypeOptimized: ForestType;
 // @beta
 export const ForestTypeReference: ForestType;
 
+// @beta
+export const getPresence: (fluidContainer: IFluidContainer_2<ContainerSchema_2>) => Presence;
+
 // @public
 export interface IConnection {
     readonly id: string;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -96,6 +96,55 @@ export enum AttachState {
     Detached = "Detached"
 }
 
+// @beta @sealed
+export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
+    readonly attendeeId: SpecificAttendeeId;
+    getConnectionId(): ClientConnectionId;
+    getConnectionStatus(): AttendeeStatus;
+}
+
+// @beta
+export type AttendeeId = SessionId & {
+    readonly AttendeeId: "AttendeeId";
+};
+
+// @beta @sealed
+export interface AttendeesEvents {
+    // @eventProperty
+    attendeeConnected: (attendee: Attendee) => void;
+    // @eventProperty
+    attendeeDisconnected: (attendee: Attendee) => void;
+}
+
+// @beta
+export const AttendeeStatus: {
+    readonly Connected: "Connected";
+    readonly Disconnected: "Disconnected";
+};
+
+// @beta
+export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
+
+// @beta
+export class BrandedType<out Brand> {
+    static [Symbol.hasInstance](value: never): value is never;
+    protected constructor();
+    protected readonly brand: (dummy: never) => Brand;
+}
+
+// @beta @sealed
+export interface BroadcastControls {
+    allowableUpdateLatencyMs: number | undefined;
+}
+
+// @beta
+export interface BroadcastControlSettings {
+    readonly allowableUpdateLatencyMs?: number;
+}
+
+// @beta
+export type ClientConnectionId = string;
+
 // @beta @input
 export interface CodecWriteOptionsBeta {
     readonly minVersionForCollab: MinimumVersionForCollab;
@@ -156,6 +205,28 @@ export interface ContainerSchema {
 
 // @beta
 export function createIndependentTreeBeta<const TSchema extends ImplicitFieldSchema>(options?: ForestOptions): ViewableTree;
+
+// @beta
+export type DeepReadonly<T, Options extends DeepReadonlyOptions = {
+    DeepenedGenerics: DeepReadonlySupportedGenericsDefault;
+    RecurseLimit: "NoLimit";
+}> = InternalCoreInterfacesUtilityTypes.DeepReadonlyImpl<T, Options extends {
+    DeepenedGenerics: unknown;
+} ? Options["DeepenedGenerics"] : DeepReadonlySupportedGenericsDefault, Options extends {
+    RecurseLimit: DeepReadonlyRecursionLimit;
+} ? Options["RecurseLimit"] : "NoLimit">;
+
+// @beta
+export interface DeepReadonlyOptions {
+    DeepenedGenerics?: ReadonlySupportedGenerics;
+    RecurseLimit?: DeepReadonlyRecursionLimit;
+}
+
+// @beta @system
+export type DeepReadonlyRecursionLimit = "NoLimit" | 0 | `+${string}`;
+
+// @beta @system
+export type DeepReadonlySupportedGenericsDefault = Map<unknown, unknown> | Promise<unknown> | Set<unknown> | WeakMap<object, unknown> | WeakSet<object>;
 
 // @public @sealed @system
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
@@ -292,7 +363,7 @@ export const ForestTypeOptimized: ForestType;
 export const ForestTypeReference: ForestType;
 
 // @beta
-export const getPresence: (fluidContainer: IFluidContainer_2<ContainerSchema_2>) => Presence;
+export const getPresence: (fluidContainer: IFluidContainer<ContainerSchema_2>) => Presence_2;
 
 // @public
 export interface IConnection {
@@ -590,6 +661,372 @@ TSchema
 // @public
 export type InsertableTypedNode<TSchema extends TreeNodeSchema, T = UnionToIntersection<TSchema>> = (T extends TreeNodeSchema<string, NodeKind, TreeNode | TreeLeafValue, never, true> ? NodeBuilderData<T> : never) | (T extends TreeNodeSchema ? Unhydrated<TreeNode extends NodeFromSchema<T> ? never : NodeFromSchema<T>> : never);
 
+// @beta @system
+export namespace InternalCoreInterfacesUtilityTypes {
+    // @system
+    export type AnyOpaqueJsonType = OpaqueJsonSerializable<unknown, any, unknown> | OpaqueJsonDeserialized<unknown, any, unknown>;
+    // @system
+    export type AnyRecord = Record<keyof any, any>;
+    // @system
+    export type DeepenReadonlyInFluidHandleIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Readonly<IFluidHandle<infer V>> ? IFluidHandle<V> extends DeepenedGenerics ? Readonly<IFluidHandle<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>>> : Readonly<T> : Else;
+    // @system
+    export type DeepenReadonlyInGenerics<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = DeepenReadonlyInMapIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInSetIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInWeakMapIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInWeakSetIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInPromiseIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInFluidHandleIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, Else>>>>>>;
+    // @system
+    export type DeepenReadonlyInMapIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends ReadonlyMap<infer K, infer V> ? Map<K, V> extends DeepenedGenerics ? ReadonlyMap<ReadonlyImpl<K, DeepenedGenerics, NoDepthOrRecurseLimit>, ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>> : ReadonlyMap<K, V> : Else;
+    // @system
+    export type DeepenReadonlyInPromiseIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Promise<infer V> ? Promise<V> extends DeepenedGenerics ? Promise<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>> : T : Else;
+    // @system
+    export type DeepenReadonlyInSetIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends ReadonlySet<infer V> ? Set<V> extends DeepenedGenerics ? ReadonlySet<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>> : ReadonlySet<V> : Else;
+    // @system
+    export type DeepenReadonlyInWeakMapIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Omit<WeakMap<infer K, infer V>, "delete" | "set"> ? WeakMap<K, V> extends DeepenedGenerics ? Omit<WeakMap<ReadonlyImpl<K, DeepenedGenerics, NoDepthOrRecurseLimit>, ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>>, "delete" | "set"> : Omit<WeakMap<K, V>, "delete" | "set"> : Else;
+    // @system
+    export type DeepenReadonlyInWeakSetIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Omit<WeakSet<infer V>, "add" | "delete"> ? WeakSet<V> extends DeepenedGenerics ? Omit<WeakSet<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>>, "add" | "delete"> : Omit<WeakSet<V>, "add" | "delete"> : Else;
+    // @system
+    export type DeepReadonlyImpl<T, DeepenedGenerics extends ReadonlySupportedGenerics, RecurseLimit extends DeepReadonlyRecursionLimit> = ReadonlyImpl<T, DeepenedGenerics, RecurseLimit>;
+    // @system
+    export type DeepReadonlyLimitingRecursion<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends RecursionLimit> = ReplaceRecursionWithMarkerAndPreserveAllowances<T, RecursionMarker, {
+        AllowExactly: [];
+        AllowExtensionOf: never;
+    }> extends infer TNoRecursionAndOnlyPublics ? IsSameType<TNoRecursionAndOnlyPublics, DeepReadonlyWorker<TNoRecursionAndOnlyPublics, DeepenedGenerics, 0>> extends true ? IfNonPublicProperties<T, {
+        AllowExactly: [];
+        AllowExtensionOf: never;
+    }, "found non-publics", "only publics"> extends "found non-publics" ? DeepReadonlyWorker<T, DeepenedGenerics, Extract<NoDepthOrRecurseLimit, RecursionLimit>> : T : DeepReadonlyWorker<T, DeepenedGenerics, Extract<NoDepthOrRecurseLimit, RecursionLimit>> : never;
+    // @system
+    export type DeepReadonlyRecursingInfinitely<T, DeepenedGenerics extends ReadonlySupportedGenerics> = T extends object ? FilterPreservingFunction<T, T extends readonly ReadonlyJsonTypeWith<infer Alternates>[] ? true extends IfExactTypeInTuple<T, [
+    JsonTypeWith<Alternates>[],
+    readonly ReadonlyJsonTypeWith<Alternates>[]
+    ]> ? readonly ReadonlyJsonTypeWith<DeepReadonlyRecursingInfinitely<Alternates, DeepenedGenerics>>[] : {
+        readonly [K in keyof T]: DeepReadonlyRecursingInfinitely<T[K], DeepenedGenerics>;
+    } : DeepenReadonlyInGenerics<T, DeepenedGenerics, "NoLimit", PreserveErasedTypeOrBrandedPrimitive<T, {
+        readonly [K in keyof T]: DeepReadonlyRecursingInfinitely<T[K], DeepenedGenerics>;
+    }>>> : T;
+    // @system
+    export type DeepReadonlyRecursion<T, DeepenedGenerics extends ReadonlySupportedGenerics, RecurseLimit extends RecursionLimit, TAncestorTypes = T> = T extends TAncestorTypes ? RecurseLimit extends `+${infer RecursionRemainder}` ? DeepReadonlyLimitingRecursion<T, DeepenedGenerics, RecursionRemainder extends RecursionLimit ? RecursionRemainder : 0> : T : DeepReadonlyWorker<T, DeepenedGenerics, RecurseLimit, TAncestorTypes | T>;
+    // @system
+    export type DeepReadonlyWorker<T, DeepenedGenerics extends ReadonlySupportedGenerics, RecurseLimit extends RecursionLimit, TAncestorTypes = T> = T extends object ? FilterPreservingFunction<T, DeepenReadonlyInGenerics<T, DeepenedGenerics, RecurseLimit, PreserveErasedTypeOrBrandedPrimitive<T, {
+        readonly [K in keyof T]: DeepReadonlyRecursion<T[K], DeepenedGenerics, RecurseLimit, TAncestorTypes>;
+    }>>> : T;
+    // @system
+    export interface DeserializedFilterControls extends FilterControlsWithSubstitution {
+        DegenerateNonNullObjectSubstitute: unknown;
+        RecursionMarkerAllowed: unknown;
+    }
+    // @system
+    export type ExcludeExactly<T, U> = IfSameType<T, U, never, T>;
+    // @system
+    export type ExcludeExactlyInTuple<T, TupleOfU extends unknown[]> = IfExactTypeInTuple<T, TupleOfU, never, T>;
+    // @system
+    export type ExtractFunctionFromIntersection<T extends object> = (T extends new (...args: infer A) => infer R ? new (...args: A) => R : unknown) & (T extends (...args: infer A) => infer R ? (...args: A) => R : unknown) extends infer Functional ? {
+        classification: unknown extends Functional ? "no Function" : Functional extends Required<T> ? "exactly Function" : "Function and more";
+        function: Functional;
+    } : never;
+    // @system
+    export interface FilterControls {
+        AllowExactly: unknown[];
+        AllowExtensionOf: unknown;
+    }
+    // @system
+    export interface FilterControlsWithSubstitution extends FilterControls {
+        DegenerateSubstitute: unknown;
+    }
+    // @system
+    export type FilterPreservingFunction<Original extends object, Filtered> = ExtractFunctionFromIntersection<Original> extends {
+        classification: infer TClassification;
+        function: infer TFunction;
+    } ? TClassification extends "exactly Function" ? TFunction : TFunction & Filtered : never;
+    // @system
+    export type FlattenIntersection<T extends AnyRecord> = T extends AnyRecord ? {
+        [K in keyof T]: T[K];
+    } : T;
+    // @system
+    export type IfEnumLike<T extends object, EnumLike = never, NotEnumLike = unknown> = T extends readonly (infer _)[] ? NotEnumLike : T extends Function ? NotEnumLike : T extends {
+        readonly [i: number]: string;
+        readonly [p: string]: number | string;
+        readonly [s: symbol]: never;
+    } ? true extends {
+        [K in keyof T]: T[K] extends never ? true : never;
+    }[keyof T] ? NotEnumLike : EnumLike : NotEnumLike;
+    export type IfExactTypeInTuple<T, Tuple extends unknown[], IfMatch = unknown, IfNoMatch = never> = Tuple extends [infer First, ...infer Rest] ? IfSameType<T, First, IfMatch, IfExactTypeInTuple<T, Rest, IfMatch, IfNoMatch>> : IfNoMatch;
+    // @system
+    export type IfExactTypeInUnion<T, Union, IfMatch = unknown, IfNoMatch = never> = IfSameType<T, never, IfSameType<Union, never, IfMatch, IfNoMatch>, IfSameType<T, Extract<Union, T>, IfMatch, IfNoMatch>>;
+    // @system
+    export type IfIndexOrBrandedKey<T extends keyof AnyRecord, IfIndexOrBranded, Otherwise> = T extends object ? IfIndexOrBranded : IfVariableStringOrNumber<T, IfIndexOrBranded, Otherwise>;
+    // @system
+    export type IfNonPublicProperties<T, Controls extends FilterControls, HasNonPublic = never, OnlyPublics = unknown> = ReplaceAllowancesAndRecursionWithNever<T, Controls> extends T ? OnlyPublics : HasNonPublic;
+    // @system
+    export type IfPossiblyUndefinedProperty<TKey extends keyof AnyRecord, TValue, Result extends {
+        IfPossiblyUndefined: unknown;
+        IfUnknownNonIndexed: unknown;
+        Otherwise: unknown;
+    }> = undefined extends TValue ? unknown extends TValue ? IfIndexOrBrandedKey<TKey, Result["Otherwise"], Result["IfUnknownNonIndexed"]> : Result["IfPossiblyUndefined"] : Result["Otherwise"];
+    // @system
+    export type IfSameType<X, Y, IfSame = unknown, IfDifferent = never> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? IfSame : IfDifferent;
+    // @system
+    export type IfVariableStringOrNumber<T, IfVariable, IfLiteral> = `${string}` extends T ? IfVariable : number extends T ? IfVariable : T extends `${infer first}${infer rest}` ? string extends first ? IfVariable : `${number}` extends first ? IfVariable : IfVariableStringOrNumber<rest, IfVariable, IfLiteral> : IfLiteral;
+    // @system
+    export type IsExactlyObject<T extends object> = IsSameType<T, object>;
+    // @system
+    export type IsSameType<X, Y> = IfSameType<X, Y, true, false>;
+    // @system
+    export type JsonDeserializedFilter<T, Controls extends DeserializedFilterControls, TAncestorTypes extends object[] = [Extract<T, object>]> = boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : unknown extends T ? Controls["DegenerateSubstitute"] : T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, [
+    ...Controls["AllowExactly"],
+    Controls["RecursionMarkerAllowed"]
+    ], true, "not found"> extends true ? T : T extends object ? ExtractFunctionFromIntersection<T> extends {
+        classification: "exactly Function";
+    } ? never : T extends readonly (infer _)[] ? {
+        [K in keyof T]: JsonForDeserializedArrayItem<T[K], Controls, JsonDeserializedRecursion<T[K], Controls, TAncestorTypes>>;
+    } : IsExactlyObject<T> extends true ? Controls["DegenerateNonNullObjectSubstitute"] : IfEnumLike<T> extends never ? T : T extends AnyOpaqueJsonType ? JsonDeserializedOpaqueConversion<T, Controls> : FlattenIntersection<{
+        [K in keyof T as NonSymbolWithDeserializablePropertyOf<T, [
+        ...Controls["AllowExactly"],
+        Controls["RecursionMarkerAllowed"]
+        ], Controls["AllowExtensionOf"], K>]: JsonDeserializedRecursion<T[K], Controls, TAncestorTypes>;
+    } & {
+        [K in keyof T as NonSymbolLiteralWithPossiblyDeserializablePropertyOf<T, [
+        ...Controls["AllowExactly"],
+        Controls["RecursionMarkerAllowed"]
+        ], Controls["AllowExtensionOf"], K>]?: JsonDeserializedRecursion<T[K], Controls, TAncestorTypes>;
+    }> : never;
+    // @system
+    export type JsonDeserializedImpl<T, Options extends Partial<FilterControls>, TypeUnderRecursion extends boolean = false> = {
+        AllowExactly: Options extends {
+            AllowExactly: unknown[];
+        } ? Options["AllowExactly"] : [];
+        AllowExtensionOf: Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never;
+        DegenerateSubstitute: JsonTypeWith<(Options extends {
+            AllowExactly: unknown[];
+        } ? TupleToUnion<Options["AllowExactly"]> : never) | (Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never)>;
+        DegenerateNonNullObjectSubstitute: NonNullJsonObjectWith<(Options extends {
+            AllowExactly: unknown[];
+        } ? TupleToUnion<Options["AllowExactly"]> : never) | (Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never)>;
+        RecursionMarkerAllowed: never;
+    } extends infer Controls ? Controls extends DeserializedFilterControls ? boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : ReplaceRecursionWithMarkerAndPreserveAllowances<T, RecursionMarker, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"] | AnyOpaqueJsonType;
+    }> extends infer TNoRecursionAndOnlyPublics ? IsSameType<TNoRecursionAndOnlyPublics, JsonDeserializedFilter<TNoRecursionAndOnlyPublics, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"];
+        DegenerateSubstitute: Controls["DegenerateSubstitute"];
+        DegenerateNonNullObjectSubstitute: Controls["DegenerateNonNullObjectSubstitute"];
+        RecursionMarkerAllowed: RecursionMarker;
+    }>> extends true ? IfNonPublicProperties<T, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"] | AnyOpaqueJsonType;
+    }, "found non-publics", "only publics"> extends "found non-publics" ? TypeUnderRecursion extends false ? JsonDeserializedFilter<T, Controls> : OpaqueJsonDeserialized<T, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : T : TypeUnderRecursion extends false ? JsonDeserializedFilter<T, Controls> : OpaqueJsonDeserialized<T, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : never : never : never;
+    // @system
+    export type JsonDeserializedOpaqueConversion<T extends AnyOpaqueJsonType, Controls extends FilterControls> = T extends OpaqueJsonSerializable<infer TData, any, unknown> | OpaqueJsonDeserialized<infer TData, any, unknown> ? OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : "internal error: failed to determine OpaqueJson* type";
+    // @system
+    export type JsonDeserializedRecursion<T, Controls extends DeserializedFilterControls, TAncestorTypes extends object[]> = IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? JsonDeserializedImpl<T, Controls, true> : T extends object ? IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? JsonDeserializedImpl<T, Controls, true> : JsonDeserializedFilter<T, Controls, [
+    ...TAncestorTypes,
+    T
+    ]> : JsonDeserializedFilter<T, Controls, TAncestorTypes>;
+    // @system
+    export type JsonForDeserializedArrayItem<T, Controls extends DeserializedFilterControls, TBlessed> = boolean extends (T extends never ? true : false) ? TBlessed : unknown extends T ? TBlessed : T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, [
+    ...Controls["AllowExactly"],
+    Controls["RecursionMarkerAllowed"]
+    ], T, T extends undefined | symbol ? null : T extends Function ? ExtractFunctionFromIntersection<T> extends {
+        classification: "exactly Function";
+    } ? null : null | TBlessed : TBlessed>;
+    // @system
+    export type JsonForSerializableArrayItem<T, Controls extends FilterControls, TAncestorTypes extends unknown[], TBlessed> = boolean extends (T extends never ? true : false) ? TBlessed : unknown extends T ? TBlessed : IfExactTypeInTuple<T, TAncestorTypes, T, T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, Controls["AllowExactly"], T, undefined extends T ? SerializationErrorPerUndefinedArrayElement : TBlessed>>;
+    // @system
+    export type JsonSerializableFilter<T, Controls extends FilterControlsWithSubstitution, TAncestorTypes extends unknown[], TNextAncestor = T> = boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : unknown extends T ? Controls["DegenerateSubstitute"] : IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? T : T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, Controls["AllowExactly"], true, "no match"> extends true ? T : Extract<T, Function> extends never ? T extends object ? T extends readonly (infer _)[] ? {
+        [K in keyof T]: JsonForSerializableArrayItem<T[K], Controls, TAncestorTypes, JsonSerializableFilter<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>>;
+    } : IsExactlyObject<T> extends true ? NonNullJsonObjectWith<TupleToUnion<Controls["AllowExactly"]> | Controls["AllowExtensionOf"]> : IfEnumLike<T> extends never ? T : T extends AnyOpaqueJsonType ? JsonSerializableOpaqueAllowances<T, Controls> : FlattenIntersection<{
+        [K in keyof T as RequiredNonSymbolKeysOf<T, K>]-?: IfPossiblyUndefinedProperty<K, T[K], {
+            IfPossiblyUndefined: {
+                ["error required property may not allow `undefined` value"]: never;
+            };
+            IfUnknownNonIndexed: {
+                ["error required property may not allow `unknown` value"]: never;
+            };
+            Otherwise: JsonSerializableFilter<T[K], Controls, [
+            TNextAncestor,
+            ...TAncestorTypes
+            ]>;
+        }>;
+    } & {
+        [K in keyof T as OptionalNonSymbolKeysOf<T, K>]?: JsonSerializableFilter<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    } & {
+        [K in keyof T & symbol]: never;
+    }> : never : never;
+    // @system
+    export type JsonSerializableImpl<T, Options extends Partial<FilterControls> & {
+        IgnoreInaccessibleMembers?: "ignore-inaccessible-members";
+    }, TAncestorTypes extends unknown[] = [], TNextAncestor = T> = {
+        AllowExactly: Options extends {
+            AllowExactly: unknown[];
+        } ? Options["AllowExactly"] : [];
+        AllowExtensionOf: Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never;
+        DegenerateSubstitute: JsonTypeWith<(Options extends {
+            AllowExactly: unknown[];
+        } ? TupleToUnion<Options["AllowExactly"]> : never) | (Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never)> | OpaqueJsonSerializable<unknown, Options extends {
+            AllowExactly: unknown[];
+        } ? Options["AllowExactly"] : [], Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never>;
+    } extends infer Controls ? Controls extends FilterControlsWithSubstitution ? boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : Options extends {
+        IgnoreInaccessibleMembers: "ignore-inaccessible-members";
+    } ? JsonSerializableFilter<T, Controls, TAncestorTypes, TNextAncestor> : IfNonPublicProperties<T, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"] | boolean | number | string | AnyOpaqueJsonType;
+    }, "found non-publics", "only publics"> extends "found non-publics" ? T extends readonly (infer _)[] ? {
+        [K in keyof T]: JsonSerializableImpl<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    } : T extends boolean | number | string ? T : SerializationErrorPerNonPublicProperties : JsonSerializableFilter<T, Controls, TAncestorTypes, TNextAncestor> : never : never;
+    // @system
+    export type JsonSerializableOpaqueAllowances<T extends AnyOpaqueJsonType, Controls extends FilterControlsWithSubstitution> = T extends OpaqueJsonSerializable<infer TData, any, unknown> | OpaqueJsonDeserialized<infer TData, any, unknown> ? T extends OpaqueJsonSerializable<TData, any, unknown> & OpaqueJsonDeserialized<TData, any, unknown> ? OpaqueJsonSerializable<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> & OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : T extends OpaqueJsonSerializable<TData, any, unknown> ? OpaqueJsonSerializable<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : T extends OpaqueJsonDeserialized<TData, any, unknown> ? OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : "internal error: failed to determine OpaqueJson* type" : never;
+    // @system
+    export type NonSymbolLiteralWithPossiblyDeserializablePropertyOf<T extends object, TExactExceptions extends unknown[], TExtendsException, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: IfIndexOrBrandedKey<K, never, ExcludeExactlyInTuple<Exclude<T[K], TExtendsException>, OmitExactlyFromTuple<TExactExceptions, unknown>> extends infer PossibleTypeLessAllowed ? Extract<IfSameType<PossibleTypeLessAllowed, unknown, undefined, PossibleTypeLessAllowed>, undefined | symbol | Function> extends never ? never : TestDeserializabilityOf<T[K], OmitExactlyFromTuple<TExactExceptions, unknown>, TExtendsException, {
+            WhenSomethingDeserializable: K;
+            WhenNeverDeserializable: never;
+        }> : never>;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type NonSymbolWithDeserializablePropertyOf<T extends object, TExactExceptions extends unknown[], TExtendsException, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: ExcludeExactlyInTuple<Exclude<T[K], TExtendsException>, OmitExactlyFromTuple<TExactExceptions, unknown>> extends infer PossibleTypeLessAllowed ? IfSameType<PossibleTypeLessAllowed, unknown, IfIndexOrBrandedKey<K, K, never>, Extract<PossibleTypeLessAllowed, undefined | symbol | Function> extends never ? IfSameType<PossibleTypeLessAllowed, bigint, never, T[K] extends never ? never : K> : TestDeserializabilityOf<T[K], OmitExactlyFromTuple<TExactExceptions, unknown>, TExtendsException, {
+            WhenSomethingDeserializable: IfIndexOrBrandedKey<K, K, never>;
+            WhenNeverDeserializable: never;
+        }>> : never;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type OmitExactlyFromTuple<Tuple extends unknown[], U, Accumulated extends unknown[] = []> = Tuple extends [infer First, ...infer Rest] ? OmitExactlyFromTuple<Rest, U, IfSameType<First, U, Accumulated, [...Accumulated, First]>> : Accumulated;
+    // @system
+    export type OmitFromTuple<Tuple extends unknown[], U, Accumulated extends unknown[] = []> = Tuple extends [infer First, ...infer Rest] ? OmitFromTuple<Rest, U, First extends U ? Accumulated : [...Accumulated, First]> : Accumulated;
+    // @system
+    export type OptionalNonSymbolKeysOf<T extends object, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: T extends Record<K, T[K]> ? never : K;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type PreserveErasedTypeOrBrandedPrimitive<T extends object, Else> = T extends ErasedType<infer _> ? T : T extends infer Brand & (boolean | number | string | symbol | bigint) ? T extends Brand & infer Primitive ? /* [potentially] branded type => "as-is" */ Primitive & Brand : T : Else;
+    // @system
+    export type ReadonlyImpl<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit> = NoDepthOrRecurseLimit extends "Shallow" ? ShallowReadonlyImpl<T, DeepenedGenerics> : NoDepthOrRecurseLimit extends "NoLimit" ? DeepReadonlyRecursingInfinitely<T, DeepenedGenerics> : DeepReadonlyLimitingRecursion<T, DeepenedGenerics, Extract<NoDepthOrRecurseLimit, RecursionLimit>>;
+    // @system
+    export type RecursionLimit = `+${string}` | 0;
+    // @system
+    export interface RecursionMarker {
+        // (undocumented)
+        [RecursionMarkerSymbol]: typeof RecursionMarkerSymbol;
+    }
+    // @system
+    export type ReplaceAllowancesAndRecursionWithNever<T, Controls extends FilterControls, TAncestorTypes extends unknown[] = [], TNextAncestor = T> = IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? never : T extends Controls["AllowExtensionOf"] ? never : IfExactTypeInTuple<T, Controls["AllowExactly"], true, "no match"> extends true ? never : IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? never : T extends object ? FilterPreservingFunction<T, {
+        [K in keyof T]: ReplaceAllowancesAndRecursionWithNever<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    }> : T;
+    // @system
+    export type ReplaceRecursionWithMarkerAndPreserveAllowances<T, TRecursionMarker, Controls extends FilterControls, TAncestorTypes extends unknown[] = [], TNextAncestor = T> = IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? TRecursionMarker : T extends infer _ ? IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? TRecursionMarker : T extends Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, Controls["AllowExactly"], true, "no match"> extends true ? T : T extends object ? FilterPreservingFunction<T, {
+        [K in keyof T]: ReplaceRecursionWithMarkerAndPreserveAllowances<T[K], TRecursionMarker, Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    }> : T : never;
+    // @system
+    export type RequiredNonSymbolKeysOf<T extends object, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: T extends Record<K, T[K]> ? K : never;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type ShallowReadonlyImpl<T, DeepenedGenerics extends ReadonlySupportedGenerics> = T extends object ? FilterPreservingFunction<T, DeepenReadonlyInGenerics<T, DeepenedGenerics, "Shallow", PreserveErasedTypeOrBrandedPrimitive<T, /* basic type => */ Readonly<T>>>> : T;
+    // @system
+    export type TestDeserializabilityOf<T, TExactExceptions extends unknown[], TExtendsException, Result extends {
+        WhenSomethingDeserializable: unknown;
+        WhenNeverDeserializable: never;
+    } | {
+        WhenSomethingDeserializable: never;
+        WhenNeverDeserializable: unknown;
+    }> = T extends never ? Result["WhenNeverDeserializable"] : T extends TExtendsException ? Result["WhenSomethingDeserializable"] : IfExactTypeInTuple<T, TExactExceptions, Result["WhenSomethingDeserializable"], T extends bigint | symbol | undefined ? Result["WhenNeverDeserializable"] : T extends Function ? ExtractFunctionFromIntersection<T> extends {
+        classification: "exactly Function";
+    } ? Result["WhenNeverDeserializable"] : Result["WhenSomethingDeserializable"] : Result["WhenSomethingDeserializable"]>;
+    // @system
+    export type TupleToUnion<T extends unknown[]> = T[number];
+        {};
+}
+
+// @beta @system
+export namespace InternalPresenceTypes {
+    // @system
+    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
+        instanceBase: new (...args: any[]) => unknown;
+    } & ((key: TKey, datastoreHandle: StateDatastoreHandle<TKey, TValue>) => {
+        initialData?: {
+            value: TValue;
+            allowableUpdateLatencyMs: number | undefined;
+        };
+        manager: StateValue<TManager>;
+    });
+    // @system
+    export interface MapValueState<T, Keys extends string> {
+        // (undocumented)
+        items: {
+            [name in Keys]: ValueOptionalState<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export interface NotificationType {
+        // (undocumented)
+        args: unknown[];
+        // (undocumented)
+        name: string;
+    }
+    // @system
+    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<unknown>> {
+    }
+    // @system
+    export type StateValue<T> = T & StateValueBrand<T>;
+    // @system
+    export class StateValueBrand<T> {
+    }
+    // @system
+    export interface ValueDirectory<T> {
+        // (undocumented)
+        items: {
+            [name: string | number]: ValueOptionalState<T> | ValueDirectory<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export type ValueDirectoryOrState<T> = ValueRequiredState<T> | ValueDirectory<T>;
+    // @system
+    export interface ValueOptionalState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value?: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueRequiredState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueStateMetadata {
+        // (undocumented)
+        rev: number;
+        // (undocumented)
+        timestamp: number;
+    }
+}
+
 // @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
@@ -677,6 +1114,36 @@ export type JsonCompatibleObject<TExtra = never> = {
     [P in string]?: JsonCompatible<TExtra>;
 };
 
+// @beta
+export type JsonDeserialized<T, Options extends JsonDeserializedOptions = {
+    AllowExactly: [];
+    AllowExtensionOf: never;
+}> = InternalCoreInterfacesUtilityTypes.JsonDeserializedImpl<T, Options>;
+
+// @beta
+export interface JsonDeserializedOptions {
+    AllowExactly?: unknown[];
+    AllowExtensionOf?: unknown;
+}
+
+// @beta
+export type JsonSerializable<T, Options extends JsonSerializableOptions = {
+    AllowExactly: [];
+    AllowExtensionOf: never;
+}> = InternalCoreInterfacesUtilityTypes.JsonSerializableImpl<T, Options>;
+
+// @beta
+export interface JsonSerializableOptions {
+    AllowExactly?: unknown[];
+    AllowExtensionOf?: unknown;
+    IgnoreInaccessibleMembers?: "ignore-inaccessible-members";
+}
+
+// @beta
+export type JsonTypeWith<T> = null | boolean | number | string | T | {
+    [key: string | number]: JsonTypeWith<T>;
+} | JsonTypeWith<T>[];
+
 // @beta @input
 export enum KeyEncodingOptions {
     allStoredKeys = "allStoredKeys",
@@ -756,6 +1223,11 @@ export interface NodeSchemaOptions<out TCustomMetadata = unknown> {
     readonly metadata?: NodeSchemaMetadata<TCustomMetadata> | undefined;
 }
 
+// @beta
+export type NonNullJsonObjectWith<T> = {
+    [key: string | number]: JsonTypeWith<T>;
+} | JsonTypeWith<T>[];
+
 // @public @system
 export type NumberKeys<T, Transformed = {
     readonly [Property in keyof T as number extends Property ? never : Property]: Property;
@@ -774,12 +1246,67 @@ export interface ObjectSchemaOptions<TCustomMetadata = unknown> extends NodeSche
 // @public
 export type Off = () => void;
 
+// @beta @sealed
+export class OpaqueJsonDeserialized<T, in out Option_AllowExactly extends unknown[] = [], out Option_AllowExtensionOf = never> extends BrandedType<"JsonDeserialized"> {
+    // (undocumented)
+    protected readonly JsonDeserialized: {
+        Type: T;
+        Options: {
+            AllowExactly: Option_AllowExactly;
+            AllowExtensionOf: Option_AllowExtensionOf;
+        };
+    };
+    // (undocumented)
+    protected readonly Option_AllowExactly_Invariance: (Option_AllowExactly: Option_AllowExactly) => void;
+}
+
+// @beta @sealed
+export class OpaqueJsonSerializable<T, in out Option_AllowExactly extends unknown[] = [], out Option_AllowExtensionOf = never> extends BrandedType<"JsonSerializable"> {
+    // (undocumented)
+    protected readonly JsonSerializable: {
+        Type: T;
+        Options: {
+            AllowExactly: Option_AllowExactly;
+            AllowExtensionOf: Option_AllowExtensionOf;
+        };
+    };
+    // (undocumented)
+    protected readonly Option_AllowExactly_Invariance: (Option_AllowExactly: Option_AllowExactly) => void;
+}
+
 // @beta @system
 export type PopUnion<Union, AsOverloadedFunction = UnionToIntersection<Union extends unknown ? (f: Union) => void : never>> = AsOverloadedFunction extends (a: infer First) => void ? First : never;
+
+// @beta @sealed
+export interface Presence {
+    readonly attendees: {
+        readonly events: Listenable<AttendeesEvents>;
+        getAttendees(): ReadonlySet<Attendee>;
+        getAttendee(clientId: ClientConnectionId | AttendeeId): Attendee;
+        getMyself(): Attendee;
+    };
+    readonly events: Listenable<PresenceEvents>;
+    readonly states: {
+        getWorkspace<StatesSchema extends StatesWorkspaceSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
+    };
+}
+
+// @beta @sealed
+export interface PresenceEvents {
+    workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
+}
 
 // @public @sealed @system
 export interface ReadonlyArrayNode<out T = TreeNode | TreeLeafValue> extends ReadonlyArray<T>, Awaited<TreeNode & WithType<string, NodeKind.Array>> {
 }
+
+// @beta
+export type ReadonlyJsonTypeWith<TReadonlyAlternates> = null | boolean | number | string | TReadonlyAlternates | {
+    readonly [key: string | number]: ReadonlyJsonTypeWith<TReadonlyAlternates>;
+} | readonly ReadonlyJsonTypeWith<TReadonlyAlternates>[];
+
+// @beta
+export type ReadonlySupportedGenerics = IFluidHandle | Map<unknown, unknown> | Promise<unknown> | Set<unknown> | WeakMap<object, unknown> | WeakSet<object>;
 
 // @beta @system
 export type RecordNodeInsertableData<T extends ImplicitAllowedTypes> = RestrictiveStringRecord<InsertableTreeNodeFromImplicitAllowedTypes<T>>;
@@ -933,6 +1460,16 @@ export class SchemaUpgrade {
 // @public @system
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
+// @beta @system
+export type SerializationErrorPerNonPublicProperties = {
+    "object serialization error": "non-public properties are not supported";
+};
+
+// @beta @system
+export type SerializationErrorPerUndefinedArrayElement = {
+    "array serialization error": "undefined elements are not supported";
+};
+
 // @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
@@ -954,6 +1491,30 @@ export interface SimpleNodeSchemaBase<out TNodeKind extends NodeKind, out TCusto
 export function singletonSchema<TScope extends string, TName extends string | number>(factory: SchemaFactory<TScope, TName>, name: TName): TreeNodeSchemaClass<ScopedSchemaName<TScope, TName>, NodeKind.Object, TreeNode & {
     readonly value: TName;
 }, Record<string, never>, true, Record<string, never>, undefined>;
+
+// @beta @sealed
+export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    readonly controls: BroadcastControls;
+    readonly presence: Presence;
+    readonly states: StatesWorkspaceEntries<TSchema>;
+}
+
+// @beta @sealed
+export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
+    /**
+    * Registered State objects.
+    */
+    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
+};
+
+// @beta
+export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
+
+// @beta
+export interface StatesWorkspaceSchema {
+    [key: string]: StatesWorkspaceEntry<typeof key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
+}
 
 // @beta @system
 export namespace System_TableSchema {
@@ -1466,5 +2027,8 @@ export interface WithType<out TName extends string = string, out TKind extends N
     get [typeNameSymbol](): TName;
     get [typeSchemaSymbol](): TreeNodeSchemaClass<TName, TKind, TreeNode, never, boolean, TInfo>;
 }
+
+// @beta
+export type WorkspaceAddress = `${string}:${string}`;
 
 ```

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -363,7 +363,7 @@ export const ForestTypeOptimized: ForestType;
 export const ForestTypeReference: ForestType;
 
 // @beta
-export const getPresence: (fluidContainer: IFluidContainer<ContainerSchema_2>) => Presence_2;
+export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @public
 export interface IConnection {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -294,6 +294,9 @@ export const ForestTypeOptimized: ForestType;
 // @beta
 export const ForestTypeReference: ForestType;
 
+// @beta
+export const getPresence: (fluidContainer: IFluidContainer_2<ContainerSchema_2>) => Presence;
+
 // @beta @legacy
 export interface IBranchOrigin {
     id: string;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -366,7 +366,7 @@ export const ForestTypeOptimized: ForestType;
 export const ForestTypeReference: ForestType;
 
 // @beta
-export const getPresence: (fluidContainer: IFluidContainer<ContainerSchema_2>) => Presence_2;
+export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @beta @legacy
 export interface IBranchOrigin {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -96,6 +96,55 @@ export enum AttachState {
     Detached = "Detached"
 }
 
+// @beta @sealed
+export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
+    readonly attendeeId: SpecificAttendeeId;
+    getConnectionId(): ClientConnectionId;
+    getConnectionStatus(): AttendeeStatus;
+}
+
+// @beta
+export type AttendeeId = SessionId & {
+    readonly AttendeeId: "AttendeeId";
+};
+
+// @beta @sealed
+export interface AttendeesEvents {
+    // @eventProperty
+    attendeeConnected: (attendee: Attendee) => void;
+    // @eventProperty
+    attendeeDisconnected: (attendee: Attendee) => void;
+}
+
+// @beta
+export const AttendeeStatus: {
+    readonly Connected: "Connected";
+    readonly Disconnected: "Disconnected";
+};
+
+// @beta
+export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
+
+// @beta
+export class BrandedType<out Brand> {
+    static [Symbol.hasInstance](value: never): value is never;
+    protected constructor();
+    protected readonly brand: (dummy: never) => Brand;
+}
+
+// @beta @sealed
+export interface BroadcastControls {
+    allowableUpdateLatencyMs: number | undefined;
+}
+
+// @beta
+export interface BroadcastControlSettings {
+    readonly allowableUpdateLatencyMs?: number;
+}
+
+// @beta
+export type ClientConnectionId = string;
+
 // @beta @input
 export interface CodecWriteOptionsBeta {
     readonly minVersionForCollab: MinimumVersionForCollab;
@@ -156,6 +205,28 @@ export interface ContainerSchema {
 
 // @beta
 export function createIndependentTreeBeta<const TSchema extends ImplicitFieldSchema>(options?: ForestOptions): ViewableTree;
+
+// @beta
+export type DeepReadonly<T, Options extends DeepReadonlyOptions = {
+    DeepenedGenerics: DeepReadonlySupportedGenericsDefault;
+    RecurseLimit: "NoLimit";
+}> = InternalCoreInterfacesUtilityTypes.DeepReadonlyImpl<T, Options extends {
+    DeepenedGenerics: unknown;
+} ? Options["DeepenedGenerics"] : DeepReadonlySupportedGenericsDefault, Options extends {
+    RecurseLimit: DeepReadonlyRecursionLimit;
+} ? Options["RecurseLimit"] : "NoLimit">;
+
+// @beta
+export interface DeepReadonlyOptions {
+    DeepenedGenerics?: ReadonlySupportedGenerics;
+    RecurseLimit?: DeepReadonlyRecursionLimit;
+}
+
+// @beta @system
+export type DeepReadonlyRecursionLimit = "NoLimit" | 0 | `+${string}`;
+
+// @beta @system
+export type DeepReadonlySupportedGenericsDefault = Map<unknown, unknown> | Promise<unknown> | Set<unknown> | WeakMap<object, unknown> | WeakSet<object>;
 
 // @public @sealed @system
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
@@ -295,7 +366,7 @@ export const ForestTypeOptimized: ForestType;
 export const ForestTypeReference: ForestType;
 
 // @beta
-export const getPresence: (fluidContainer: IFluidContainer_2<ContainerSchema_2>) => Presence;
+export const getPresence: (fluidContainer: IFluidContainer<ContainerSchema_2>) => Presence_2;
 
 // @beta @legacy
 export interface IBranchOrigin {
@@ -639,6 +710,372 @@ export type InsertableTypedNode<TSchema extends TreeNodeSchema, T = UnionToInter
 
 export { InteriorSequencePlace }
 
+// @beta @system
+export namespace InternalCoreInterfacesUtilityTypes {
+    // @system
+    export type AnyOpaqueJsonType = OpaqueJsonSerializable<unknown, any, unknown> | OpaqueJsonDeserialized<unknown, any, unknown>;
+    // @system
+    export type AnyRecord = Record<keyof any, any>;
+    // @system
+    export type DeepenReadonlyInFluidHandleIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Readonly<IFluidHandle<infer V>> ? IFluidHandle<V> extends DeepenedGenerics ? Readonly<IFluidHandle<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>>> : Readonly<T> : Else;
+    // @system
+    export type DeepenReadonlyInGenerics<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = DeepenReadonlyInMapIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInSetIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInWeakMapIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInWeakSetIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInPromiseIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, DeepenReadonlyInFluidHandleIfEnabled<T, DeepenedGenerics, NoDepthOrRecurseLimit, Else>>>>>>;
+    // @system
+    export type DeepenReadonlyInMapIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends ReadonlyMap<infer K, infer V> ? Map<K, V> extends DeepenedGenerics ? ReadonlyMap<ReadonlyImpl<K, DeepenedGenerics, NoDepthOrRecurseLimit>, ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>> : ReadonlyMap<K, V> : Else;
+    // @system
+    export type DeepenReadonlyInPromiseIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Promise<infer V> ? Promise<V> extends DeepenedGenerics ? Promise<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>> : T : Else;
+    // @system
+    export type DeepenReadonlyInSetIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends ReadonlySet<infer V> ? Set<V> extends DeepenedGenerics ? ReadonlySet<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>> : ReadonlySet<V> : Else;
+    // @system
+    export type DeepenReadonlyInWeakMapIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Omit<WeakMap<infer K, infer V>, "delete" | "set"> ? WeakMap<K, V> extends DeepenedGenerics ? Omit<WeakMap<ReadonlyImpl<K, DeepenedGenerics, NoDepthOrRecurseLimit>, ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>>, "delete" | "set"> : Omit<WeakMap<K, V>, "delete" | "set"> : Else;
+    // @system
+    export type DeepenReadonlyInWeakSetIfEnabled<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit, Else> = T extends Omit<WeakSet<infer V>, "add" | "delete"> ? WeakSet<V> extends DeepenedGenerics ? Omit<WeakSet<ReadonlyImpl<V, DeepenedGenerics, NoDepthOrRecurseLimit>>, "add" | "delete"> : Omit<WeakSet<V>, "add" | "delete"> : Else;
+    // @system
+    export type DeepReadonlyImpl<T, DeepenedGenerics extends ReadonlySupportedGenerics, RecurseLimit extends DeepReadonlyRecursionLimit> = ReadonlyImpl<T, DeepenedGenerics, RecurseLimit>;
+    // @system
+    export type DeepReadonlyLimitingRecursion<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends RecursionLimit> = ReplaceRecursionWithMarkerAndPreserveAllowances<T, RecursionMarker, {
+        AllowExactly: [];
+        AllowExtensionOf: never;
+    }> extends infer TNoRecursionAndOnlyPublics ? IsSameType<TNoRecursionAndOnlyPublics, DeepReadonlyWorker<TNoRecursionAndOnlyPublics, DeepenedGenerics, 0>> extends true ? IfNonPublicProperties<T, {
+        AllowExactly: [];
+        AllowExtensionOf: never;
+    }, "found non-publics", "only publics"> extends "found non-publics" ? DeepReadonlyWorker<T, DeepenedGenerics, Extract<NoDepthOrRecurseLimit, RecursionLimit>> : T : DeepReadonlyWorker<T, DeepenedGenerics, Extract<NoDepthOrRecurseLimit, RecursionLimit>> : never;
+    // @system
+    export type DeepReadonlyRecursingInfinitely<T, DeepenedGenerics extends ReadonlySupportedGenerics> = T extends object ? FilterPreservingFunction<T, T extends readonly ReadonlyJsonTypeWith<infer Alternates>[] ? true extends IfExactTypeInTuple<T, [
+    JsonTypeWith<Alternates>[],
+    readonly ReadonlyJsonTypeWith<Alternates>[]
+    ]> ? readonly ReadonlyJsonTypeWith<DeepReadonlyRecursingInfinitely<Alternates, DeepenedGenerics>>[] : {
+        readonly [K in keyof T]: DeepReadonlyRecursingInfinitely<T[K], DeepenedGenerics>;
+    } : DeepenReadonlyInGenerics<T, DeepenedGenerics, "NoLimit", PreserveErasedTypeOrBrandedPrimitive<T, {
+        readonly [K in keyof T]: DeepReadonlyRecursingInfinitely<T[K], DeepenedGenerics>;
+    }>>> : T;
+    // @system
+    export type DeepReadonlyRecursion<T, DeepenedGenerics extends ReadonlySupportedGenerics, RecurseLimit extends RecursionLimit, TAncestorTypes = T> = T extends TAncestorTypes ? RecurseLimit extends `+${infer RecursionRemainder}` ? DeepReadonlyLimitingRecursion<T, DeepenedGenerics, RecursionRemainder extends RecursionLimit ? RecursionRemainder : 0> : T : DeepReadonlyWorker<T, DeepenedGenerics, RecurseLimit, TAncestorTypes | T>;
+    // @system
+    export type DeepReadonlyWorker<T, DeepenedGenerics extends ReadonlySupportedGenerics, RecurseLimit extends RecursionLimit, TAncestorTypes = T> = T extends object ? FilterPreservingFunction<T, DeepenReadonlyInGenerics<T, DeepenedGenerics, RecurseLimit, PreserveErasedTypeOrBrandedPrimitive<T, {
+        readonly [K in keyof T]: DeepReadonlyRecursion<T[K], DeepenedGenerics, RecurseLimit, TAncestorTypes>;
+    }>>> : T;
+    // @system
+    export interface DeserializedFilterControls extends FilterControlsWithSubstitution {
+        DegenerateNonNullObjectSubstitute: unknown;
+        RecursionMarkerAllowed: unknown;
+    }
+    // @system
+    export type ExcludeExactly<T, U> = IfSameType<T, U, never, T>;
+    // @system
+    export type ExcludeExactlyInTuple<T, TupleOfU extends unknown[]> = IfExactTypeInTuple<T, TupleOfU, never, T>;
+    // @system
+    export type ExtractFunctionFromIntersection<T extends object> = (T extends new (...args: infer A) => infer R ? new (...args: A) => R : unknown) & (T extends (...args: infer A) => infer R ? (...args: A) => R : unknown) extends infer Functional ? {
+        classification: unknown extends Functional ? "no Function" : Functional extends Required<T> ? "exactly Function" : "Function and more";
+        function: Functional;
+    } : never;
+    // @system
+    export interface FilterControls {
+        AllowExactly: unknown[];
+        AllowExtensionOf: unknown;
+    }
+    // @system
+    export interface FilterControlsWithSubstitution extends FilterControls {
+        DegenerateSubstitute: unknown;
+    }
+    // @system
+    export type FilterPreservingFunction<Original extends object, Filtered> = ExtractFunctionFromIntersection<Original> extends {
+        classification: infer TClassification;
+        function: infer TFunction;
+    } ? TClassification extends "exactly Function" ? TFunction : TFunction & Filtered : never;
+    // @system
+    export type FlattenIntersection<T extends AnyRecord> = T extends AnyRecord ? {
+        [K in keyof T]: T[K];
+    } : T;
+    // @system
+    export type IfEnumLike<T extends object, EnumLike = never, NotEnumLike = unknown> = T extends readonly (infer _)[] ? NotEnumLike : T extends Function ? NotEnumLike : T extends {
+        readonly [i: number]: string;
+        readonly [p: string]: number | string;
+        readonly [s: symbol]: never;
+    } ? true extends {
+        [K in keyof T]: T[K] extends never ? true : never;
+    }[keyof T] ? NotEnumLike : EnumLike : NotEnumLike;
+    export type IfExactTypeInTuple<T, Tuple extends unknown[], IfMatch = unknown, IfNoMatch = never> = Tuple extends [infer First, ...infer Rest] ? IfSameType<T, First, IfMatch, IfExactTypeInTuple<T, Rest, IfMatch, IfNoMatch>> : IfNoMatch;
+    // @system
+    export type IfExactTypeInUnion<T, Union, IfMatch = unknown, IfNoMatch = never> = IfSameType<T, never, IfSameType<Union, never, IfMatch, IfNoMatch>, IfSameType<T, Extract<Union, T>, IfMatch, IfNoMatch>>;
+    // @system
+    export type IfIndexOrBrandedKey<T extends keyof AnyRecord, IfIndexOrBranded, Otherwise> = T extends object ? IfIndexOrBranded : IfVariableStringOrNumber<T, IfIndexOrBranded, Otherwise>;
+    // @system
+    export type IfNonPublicProperties<T, Controls extends FilterControls, HasNonPublic = never, OnlyPublics = unknown> = ReplaceAllowancesAndRecursionWithNever<T, Controls> extends T ? OnlyPublics : HasNonPublic;
+    // @system
+    export type IfPossiblyUndefinedProperty<TKey extends keyof AnyRecord, TValue, Result extends {
+        IfPossiblyUndefined: unknown;
+        IfUnknownNonIndexed: unknown;
+        Otherwise: unknown;
+    }> = undefined extends TValue ? unknown extends TValue ? IfIndexOrBrandedKey<TKey, Result["Otherwise"], Result["IfUnknownNonIndexed"]> : Result["IfPossiblyUndefined"] : Result["Otherwise"];
+    // @system
+    export type IfSameType<X, Y, IfSame = unknown, IfDifferent = never> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? IfSame : IfDifferent;
+    // @system
+    export type IfVariableStringOrNumber<T, IfVariable, IfLiteral> = `${string}` extends T ? IfVariable : number extends T ? IfVariable : T extends `${infer first}${infer rest}` ? string extends first ? IfVariable : `${number}` extends first ? IfVariable : IfVariableStringOrNumber<rest, IfVariable, IfLiteral> : IfLiteral;
+    // @system
+    export type IsExactlyObject<T extends object> = IsSameType<T, object>;
+    // @system
+    export type IsSameType<X, Y> = IfSameType<X, Y, true, false>;
+    // @system
+    export type JsonDeserializedFilter<T, Controls extends DeserializedFilterControls, TAncestorTypes extends object[] = [Extract<T, object>]> = boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : unknown extends T ? Controls["DegenerateSubstitute"] : T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, [
+    ...Controls["AllowExactly"],
+    Controls["RecursionMarkerAllowed"]
+    ], true, "not found"> extends true ? T : T extends object ? ExtractFunctionFromIntersection<T> extends {
+        classification: "exactly Function";
+    } ? never : T extends readonly (infer _)[] ? {
+        [K in keyof T]: JsonForDeserializedArrayItem<T[K], Controls, JsonDeserializedRecursion<T[K], Controls, TAncestorTypes>>;
+    } : IsExactlyObject<T> extends true ? Controls["DegenerateNonNullObjectSubstitute"] : IfEnumLike<T> extends never ? T : T extends AnyOpaqueJsonType ? JsonDeserializedOpaqueConversion<T, Controls> : FlattenIntersection<{
+        [K in keyof T as NonSymbolWithDeserializablePropertyOf<T, [
+        ...Controls["AllowExactly"],
+        Controls["RecursionMarkerAllowed"]
+        ], Controls["AllowExtensionOf"], K>]: JsonDeserializedRecursion<T[K], Controls, TAncestorTypes>;
+    } & {
+        [K in keyof T as NonSymbolLiteralWithPossiblyDeserializablePropertyOf<T, [
+        ...Controls["AllowExactly"],
+        Controls["RecursionMarkerAllowed"]
+        ], Controls["AllowExtensionOf"], K>]?: JsonDeserializedRecursion<T[K], Controls, TAncestorTypes>;
+    }> : never;
+    // @system
+    export type JsonDeserializedImpl<T, Options extends Partial<FilterControls>, TypeUnderRecursion extends boolean = false> = {
+        AllowExactly: Options extends {
+            AllowExactly: unknown[];
+        } ? Options["AllowExactly"] : [];
+        AllowExtensionOf: Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never;
+        DegenerateSubstitute: JsonTypeWith<(Options extends {
+            AllowExactly: unknown[];
+        } ? TupleToUnion<Options["AllowExactly"]> : never) | (Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never)>;
+        DegenerateNonNullObjectSubstitute: NonNullJsonObjectWith<(Options extends {
+            AllowExactly: unknown[];
+        } ? TupleToUnion<Options["AllowExactly"]> : never) | (Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never)>;
+        RecursionMarkerAllowed: never;
+    } extends infer Controls ? Controls extends DeserializedFilterControls ? boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : ReplaceRecursionWithMarkerAndPreserveAllowances<T, RecursionMarker, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"] | AnyOpaqueJsonType;
+    }> extends infer TNoRecursionAndOnlyPublics ? IsSameType<TNoRecursionAndOnlyPublics, JsonDeserializedFilter<TNoRecursionAndOnlyPublics, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"];
+        DegenerateSubstitute: Controls["DegenerateSubstitute"];
+        DegenerateNonNullObjectSubstitute: Controls["DegenerateNonNullObjectSubstitute"];
+        RecursionMarkerAllowed: RecursionMarker;
+    }>> extends true ? IfNonPublicProperties<T, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"] | AnyOpaqueJsonType;
+    }, "found non-publics", "only publics"> extends "found non-publics" ? TypeUnderRecursion extends false ? JsonDeserializedFilter<T, Controls> : OpaqueJsonDeserialized<T, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : T : TypeUnderRecursion extends false ? JsonDeserializedFilter<T, Controls> : OpaqueJsonDeserialized<T, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : never : never : never;
+    // @system
+    export type JsonDeserializedOpaqueConversion<T extends AnyOpaqueJsonType, Controls extends FilterControls> = T extends OpaqueJsonSerializable<infer TData, any, unknown> | OpaqueJsonDeserialized<infer TData, any, unknown> ? OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : "internal error: failed to determine OpaqueJson* type";
+    // @system
+    export type JsonDeserializedRecursion<T, Controls extends DeserializedFilterControls, TAncestorTypes extends object[]> = IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? JsonDeserializedImpl<T, Controls, true> : T extends object ? IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? JsonDeserializedImpl<T, Controls, true> : JsonDeserializedFilter<T, Controls, [
+    ...TAncestorTypes,
+    T
+    ]> : JsonDeserializedFilter<T, Controls, TAncestorTypes>;
+    // @system
+    export type JsonForDeserializedArrayItem<T, Controls extends DeserializedFilterControls, TBlessed> = boolean extends (T extends never ? true : false) ? TBlessed : unknown extends T ? TBlessed : T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, [
+    ...Controls["AllowExactly"],
+    Controls["RecursionMarkerAllowed"]
+    ], T, T extends undefined | symbol ? null : T extends Function ? ExtractFunctionFromIntersection<T> extends {
+        classification: "exactly Function";
+    } ? null : null | TBlessed : TBlessed>;
+    // @system
+    export type JsonForSerializableArrayItem<T, Controls extends FilterControls, TAncestorTypes extends unknown[], TBlessed> = boolean extends (T extends never ? true : false) ? TBlessed : unknown extends T ? TBlessed : IfExactTypeInTuple<T, TAncestorTypes, T, T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, Controls["AllowExactly"], T, undefined extends T ? SerializationErrorPerUndefinedArrayElement : TBlessed>>;
+    // @system
+    export type JsonSerializableFilter<T, Controls extends FilterControlsWithSubstitution, TAncestorTypes extends unknown[], TNextAncestor = T> = boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : unknown extends T ? Controls["DegenerateSubstitute"] : IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? T : T extends null | boolean | number | string | Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, Controls["AllowExactly"], true, "no match"> extends true ? T : Extract<T, Function> extends never ? T extends object ? T extends readonly (infer _)[] ? {
+        [K in keyof T]: JsonForSerializableArrayItem<T[K], Controls, TAncestorTypes, JsonSerializableFilter<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>>;
+    } : IsExactlyObject<T> extends true ? NonNullJsonObjectWith<TupleToUnion<Controls["AllowExactly"]> | Controls["AllowExtensionOf"]> : IfEnumLike<T> extends never ? T : T extends AnyOpaqueJsonType ? JsonSerializableOpaqueAllowances<T, Controls> : FlattenIntersection<{
+        [K in keyof T as RequiredNonSymbolKeysOf<T, K>]-?: IfPossiblyUndefinedProperty<K, T[K], {
+            IfPossiblyUndefined: {
+                ["error required property may not allow `undefined` value"]: never;
+            };
+            IfUnknownNonIndexed: {
+                ["error required property may not allow `unknown` value"]: never;
+            };
+            Otherwise: JsonSerializableFilter<T[K], Controls, [
+            TNextAncestor,
+            ...TAncestorTypes
+            ]>;
+        }>;
+    } & {
+        [K in keyof T as OptionalNonSymbolKeysOf<T, K>]?: JsonSerializableFilter<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    } & {
+        [K in keyof T & symbol]: never;
+    }> : never : never;
+    // @system
+    export type JsonSerializableImpl<T, Options extends Partial<FilterControls> & {
+        IgnoreInaccessibleMembers?: "ignore-inaccessible-members";
+    }, TAncestorTypes extends unknown[] = [], TNextAncestor = T> = {
+        AllowExactly: Options extends {
+            AllowExactly: unknown[];
+        } ? Options["AllowExactly"] : [];
+        AllowExtensionOf: Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never;
+        DegenerateSubstitute: JsonTypeWith<(Options extends {
+            AllowExactly: unknown[];
+        } ? TupleToUnion<Options["AllowExactly"]> : never) | (Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never)> | OpaqueJsonSerializable<unknown, Options extends {
+            AllowExactly: unknown[];
+        } ? Options["AllowExactly"] : [], Options extends {
+            AllowExtensionOf: unknown;
+        } ? Options["AllowExtensionOf"] : never>;
+    } extends infer Controls ? Controls extends FilterControlsWithSubstitution ? boolean extends (T extends never ? true : false) ? Controls["DegenerateSubstitute"] : Options extends {
+        IgnoreInaccessibleMembers: "ignore-inaccessible-members";
+    } ? JsonSerializableFilter<T, Controls, TAncestorTypes, TNextAncestor> : IfNonPublicProperties<T, {
+        AllowExactly: Controls["AllowExactly"];
+        AllowExtensionOf: Controls["AllowExtensionOf"] | boolean | number | string | AnyOpaqueJsonType;
+    }, "found non-publics", "only publics"> extends "found non-publics" ? T extends readonly (infer _)[] ? {
+        [K in keyof T]: JsonSerializableImpl<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    } : T extends boolean | number | string ? T : SerializationErrorPerNonPublicProperties : JsonSerializableFilter<T, Controls, TAncestorTypes, TNextAncestor> : never : never;
+    // @system
+    export type JsonSerializableOpaqueAllowances<T extends AnyOpaqueJsonType, Controls extends FilterControlsWithSubstitution> = T extends OpaqueJsonSerializable<infer TData, any, unknown> | OpaqueJsonDeserialized<infer TData, any, unknown> ? T extends OpaqueJsonSerializable<TData, any, unknown> & OpaqueJsonDeserialized<TData, any, unknown> ? OpaqueJsonSerializable<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> & OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : T extends OpaqueJsonSerializable<TData, any, unknown> ? OpaqueJsonSerializable<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : T extends OpaqueJsonDeserialized<TData, any, unknown> ? OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> : "internal error: failed to determine OpaqueJson* type" : never;
+    // @system
+    export type NonSymbolLiteralWithPossiblyDeserializablePropertyOf<T extends object, TExactExceptions extends unknown[], TExtendsException, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: IfIndexOrBrandedKey<K, never, ExcludeExactlyInTuple<Exclude<T[K], TExtendsException>, OmitExactlyFromTuple<TExactExceptions, unknown>> extends infer PossibleTypeLessAllowed ? Extract<IfSameType<PossibleTypeLessAllowed, unknown, undefined, PossibleTypeLessAllowed>, undefined | symbol | Function> extends never ? never : TestDeserializabilityOf<T[K], OmitExactlyFromTuple<TExactExceptions, unknown>, TExtendsException, {
+            WhenSomethingDeserializable: K;
+            WhenNeverDeserializable: never;
+        }> : never>;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type NonSymbolWithDeserializablePropertyOf<T extends object, TExactExceptions extends unknown[], TExtendsException, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: ExcludeExactlyInTuple<Exclude<T[K], TExtendsException>, OmitExactlyFromTuple<TExactExceptions, unknown>> extends infer PossibleTypeLessAllowed ? IfSameType<PossibleTypeLessAllowed, unknown, IfIndexOrBrandedKey<K, K, never>, Extract<PossibleTypeLessAllowed, undefined | symbol | Function> extends never ? IfSameType<PossibleTypeLessAllowed, bigint, never, T[K] extends never ? never : K> : TestDeserializabilityOf<T[K], OmitExactlyFromTuple<TExactExceptions, unknown>, TExtendsException, {
+            WhenSomethingDeserializable: IfIndexOrBrandedKey<K, K, never>;
+            WhenNeverDeserializable: never;
+        }>> : never;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type OmitExactlyFromTuple<Tuple extends unknown[], U, Accumulated extends unknown[] = []> = Tuple extends [infer First, ...infer Rest] ? OmitExactlyFromTuple<Rest, U, IfSameType<First, U, Accumulated, [...Accumulated, First]>> : Accumulated;
+    // @system
+    export type OmitFromTuple<Tuple extends unknown[], U, Accumulated extends unknown[] = []> = Tuple extends [infer First, ...infer Rest] ? OmitFromTuple<Rest, U, First extends U ? Accumulated : [...Accumulated, First]> : Accumulated;
+    // @system
+    export type OptionalNonSymbolKeysOf<T extends object, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: T extends Record<K, T[K]> ? never : K;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type PreserveErasedTypeOrBrandedPrimitive<T extends object, Else> = T extends ErasedType<infer _> ? T : T extends infer Brand & (boolean | number | string | symbol | bigint) ? T extends Brand & infer Primitive ? /* [potentially] branded type => "as-is" */ Primitive & Brand : T : Else;
+    // @system
+    export type ReadonlyImpl<T, DeepenedGenerics extends ReadonlySupportedGenerics, NoDepthOrRecurseLimit extends "Shallow" | DeepReadonlyRecursionLimit> = NoDepthOrRecurseLimit extends "Shallow" ? ShallowReadonlyImpl<T, DeepenedGenerics> : NoDepthOrRecurseLimit extends "NoLimit" ? DeepReadonlyRecursingInfinitely<T, DeepenedGenerics> : DeepReadonlyLimitingRecursion<T, DeepenedGenerics, Extract<NoDepthOrRecurseLimit, RecursionLimit>>;
+    // @system
+    export type RecursionLimit = `+${string}` | 0;
+    // @system
+    export interface RecursionMarker {
+        // (undocumented)
+        [RecursionMarkerSymbol]: typeof RecursionMarkerSymbol;
+    }
+    // @system
+    export type ReplaceAllowancesAndRecursionWithNever<T, Controls extends FilterControls, TAncestorTypes extends unknown[] = [], TNextAncestor = T> = IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? never : T extends Controls["AllowExtensionOf"] ? never : IfExactTypeInTuple<T, Controls["AllowExactly"], true, "no match"> extends true ? never : IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? never : T extends object ? FilterPreservingFunction<T, {
+        [K in keyof T]: ReplaceAllowancesAndRecursionWithNever<T[K], Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    }> : T;
+    // @system
+    export type ReplaceRecursionWithMarkerAndPreserveAllowances<T, TRecursionMarker, Controls extends FilterControls, TAncestorTypes extends unknown[] = [], TNextAncestor = T> = IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? TRecursionMarker : T extends infer _ ? IfExactTypeInTuple<T, TAncestorTypes, true, "no match"> extends true ? TRecursionMarker : T extends Controls["AllowExtensionOf"] ? T : IfExactTypeInTuple<T, Controls["AllowExactly"], true, "no match"> extends true ? T : T extends object ? FilterPreservingFunction<T, {
+        [K in keyof T]: ReplaceRecursionWithMarkerAndPreserveAllowances<T[K], TRecursionMarker, Controls, [
+        TNextAncestor,
+        ...TAncestorTypes
+        ]>;
+    }> : T : never;
+    // @system
+    export type RequiredNonSymbolKeysOf<T extends object, Keys extends keyof T = keyof T> = Exclude<{
+        [K in Keys]: T extends Record<K, T[K]> ? K : never;
+    }[Keys], undefined | symbol> extends infer Result ? IfSameType<Keys, Result, Keys, Extract<Result, string | number>> : never;
+    // @system
+    export type ShallowReadonlyImpl<T, DeepenedGenerics extends ReadonlySupportedGenerics> = T extends object ? FilterPreservingFunction<T, DeepenReadonlyInGenerics<T, DeepenedGenerics, "Shallow", PreserveErasedTypeOrBrandedPrimitive<T, /* basic type => */ Readonly<T>>>> : T;
+    // @system
+    export type TestDeserializabilityOf<T, TExactExceptions extends unknown[], TExtendsException, Result extends {
+        WhenSomethingDeserializable: unknown;
+        WhenNeverDeserializable: never;
+    } | {
+        WhenSomethingDeserializable: never;
+        WhenNeverDeserializable: unknown;
+    }> = T extends never ? Result["WhenNeverDeserializable"] : T extends TExtendsException ? Result["WhenSomethingDeserializable"] : IfExactTypeInTuple<T, TExactExceptions, Result["WhenSomethingDeserializable"], T extends bigint | symbol | undefined ? Result["WhenNeverDeserializable"] : T extends Function ? ExtractFunctionFromIntersection<T> extends {
+        classification: "exactly Function";
+    } ? Result["WhenNeverDeserializable"] : Result["WhenSomethingDeserializable"] : Result["WhenSomethingDeserializable"]>;
+    // @system
+    export type TupleToUnion<T extends unknown[]> = T[number];
+        {};
+}
+
+// @beta @system
+export namespace InternalPresenceTypes {
+    // @system
+    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
+        instanceBase: new (...args: any[]) => unknown;
+    } & ((key: TKey, datastoreHandle: StateDatastoreHandle<TKey, TValue>) => {
+        initialData?: {
+            value: TValue;
+            allowableUpdateLatencyMs: number | undefined;
+        };
+        manager: StateValue<TManager>;
+    });
+    // @system
+    export interface MapValueState<T, Keys extends string> {
+        // (undocumented)
+        items: {
+            [name in Keys]: ValueOptionalState<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export interface NotificationType {
+        // (undocumented)
+        args: unknown[];
+        // (undocumented)
+        name: string;
+    }
+    // @system
+    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<unknown>> {
+    }
+    // @system
+    export type StateValue<T> = T & StateValueBrand<T>;
+    // @system
+    export class StateValueBrand<T> {
+    }
+    // @system
+    export interface ValueDirectory<T> {
+        // (undocumented)
+        items: {
+            [name: string | number]: ValueOptionalState<T> | ValueDirectory<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export type ValueDirectoryOrState<T> = ValueRequiredState<T> | ValueDirectory<T>;
+    // @system
+    export interface ValueOptionalState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value?: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueRequiredState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueStateMetadata {
+        // (undocumented)
+        rev: number;
+        // (undocumented)
+        timestamp: number;
+    }
+}
+
 // @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
@@ -957,6 +1394,36 @@ export type JsonCompatibleObject<TExtra = never> = {
     [P in string]?: JsonCompatible<TExtra>;
 };
 
+// @beta
+export type JsonDeserialized<T, Options extends JsonDeserializedOptions = {
+    AllowExactly: [];
+    AllowExtensionOf: never;
+}> = InternalCoreInterfacesUtilityTypes.JsonDeserializedImpl<T, Options>;
+
+// @beta
+export interface JsonDeserializedOptions {
+    AllowExactly?: unknown[];
+    AllowExtensionOf?: unknown;
+}
+
+// @beta
+export type JsonSerializable<T, Options extends JsonSerializableOptions = {
+    AllowExactly: [];
+    AllowExtensionOf: never;
+}> = InternalCoreInterfacesUtilityTypes.JsonSerializableImpl<T, Options>;
+
+// @beta
+export interface JsonSerializableOptions {
+    AllowExactly?: unknown[];
+    AllowExtensionOf?: unknown;
+    IgnoreInaccessibleMembers?: "ignore-inaccessible-members";
+}
+
+// @beta
+export type JsonTypeWith<T> = null | boolean | number | string | T | {
+    [key: string | number]: JsonTypeWith<T>;
+} | JsonTypeWith<T>[];
+
 // @beta @input
 export enum KeyEncodingOptions {
     allStoredKeys = "allStoredKeys",
@@ -1036,6 +1503,11 @@ export interface NodeSchemaOptions<out TCustomMetadata = unknown> {
     readonly metadata?: NodeSchemaMetadata<TCustomMetadata> | undefined;
 }
 
+// @beta
+export type NonNullJsonObjectWith<T> = {
+    [key: string | number]: JsonTypeWith<T>;
+} | JsonTypeWith<T>[];
+
 // @public @system
 export type NumberKeys<T, Transformed = {
     readonly [Property in keyof T as number extends Property ? never : Property]: Property;
@@ -1054,12 +1526,67 @@ export interface ObjectSchemaOptions<TCustomMetadata = unknown> extends NodeSche
 // @public
 export type Off = () => void;
 
+// @beta @sealed
+export class OpaqueJsonDeserialized<T, in out Option_AllowExactly extends unknown[] = [], out Option_AllowExtensionOf = never> extends BrandedType<"JsonDeserialized"> {
+    // (undocumented)
+    protected readonly JsonDeserialized: {
+        Type: T;
+        Options: {
+            AllowExactly: Option_AllowExactly;
+            AllowExtensionOf: Option_AllowExtensionOf;
+        };
+    };
+    // (undocumented)
+    protected readonly Option_AllowExactly_Invariance: (Option_AllowExactly: Option_AllowExactly) => void;
+}
+
+// @beta @sealed
+export class OpaqueJsonSerializable<T, in out Option_AllowExactly extends unknown[] = [], out Option_AllowExtensionOf = never> extends BrandedType<"JsonSerializable"> {
+    // (undocumented)
+    protected readonly JsonSerializable: {
+        Type: T;
+        Options: {
+            AllowExactly: Option_AllowExactly;
+            AllowExtensionOf: Option_AllowExtensionOf;
+        };
+    };
+    // (undocumented)
+    protected readonly Option_AllowExactly_Invariance: (Option_AllowExactly: Option_AllowExactly) => void;
+}
+
 // @beta @system
 export type PopUnion<Union, AsOverloadedFunction = UnionToIntersection<Union extends unknown ? (f: Union) => void : never>> = AsOverloadedFunction extends (a: infer First) => void ? First : never;
+
+// @beta @sealed
+export interface Presence {
+    readonly attendees: {
+        readonly events: Listenable<AttendeesEvents>;
+        getAttendees(): ReadonlySet<Attendee>;
+        getAttendee(clientId: ClientConnectionId | AttendeeId): Attendee;
+        getMyself(): Attendee;
+    };
+    readonly events: Listenable<PresenceEvents>;
+    readonly states: {
+        getWorkspace<StatesSchema extends StatesWorkspaceSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
+    };
+}
+
+// @beta @sealed
+export interface PresenceEvents {
+    workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
+}
 
 // @public @sealed @system
 export interface ReadonlyArrayNode<out T = TreeNode | TreeLeafValue> extends ReadonlyArray<T>, Awaited<TreeNode & WithType<string, NodeKind.Array>> {
 }
+
+// @beta
+export type ReadonlyJsonTypeWith<TReadonlyAlternates> = null | boolean | number | string | TReadonlyAlternates | {
+    readonly [key: string | number]: ReadonlyJsonTypeWith<TReadonlyAlternates>;
+} | readonly ReadonlyJsonTypeWith<TReadonlyAlternates>[];
+
+// @beta
+export type ReadonlySupportedGenerics = IFluidHandle | Map<unknown, unknown> | Promise<unknown> | Set<unknown> | WeakMap<object, unknown> | WeakSet<object>;
 
 // @beta @system
 export type RecordNodeInsertableData<T extends ImplicitAllowedTypes> = RestrictiveStringRecord<InsertableTreeNodeFromImplicitAllowedTypes<T>>;
@@ -1270,6 +1797,16 @@ export interface SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMainten
 
 export { SequencePlace }
 
+// @beta @system
+export type SerializationErrorPerNonPublicProperties = {
+    "object serialization error": "non-public properties are not supported";
+};
+
+// @beta @system
+export type SerializationErrorPerUndefinedArrayElement = {
+    "array serialization error": "undefined elements are not supported";
+};
+
 // @beta @legacy
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory> & SharedObjectKind_2<ISharedDirectory>;
 
@@ -1314,6 +1851,30 @@ export interface SimpleNodeSchemaBase<out TNodeKind extends NodeKind, out TCusto
 export function singletonSchema<TScope extends string, TName extends string | number>(factory: SchemaFactory<TScope, TName>, name: TName): TreeNodeSchemaClass<ScopedSchemaName<TScope, TName>, NodeKind.Object, TreeNode & {
     readonly value: TName;
 }, Record<string, never>, true, Record<string, never>, undefined>;
+
+// @beta @sealed
+export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    readonly controls: BroadcastControls;
+    readonly presence: Presence;
+    readonly states: StatesWorkspaceEntries<TSchema>;
+}
+
+// @beta @sealed
+export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
+    /**
+    * Registered State objects.
+    */
+    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
+};
+
+// @beta
+export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
+
+// @beta
+export interface StatesWorkspaceSchema {
+    [key: string]: StatesWorkspaceEntry<typeof key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
+}
 
 // @beta @system
 export namespace System_TableSchema {
@@ -1826,5 +2387,8 @@ export interface WithType<out TName extends string = string, out TKind extends N
     get [typeNameSymbol](): TName;
     get [typeSchemaSymbol](): TreeNodeSchemaClass<TName, TKind, TreeNode, never, boolean, TInfo>;
 }
+
+// @beta
+export type WorkspaceAddress = `${string}:${string}`;
 
 ```

--- a/packages/framework/fluid-framework/eslint.config.mts
+++ b/packages/framework/fluid-framework/eslint.config.mts
@@ -6,14 +6,6 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [
-	...strict,
-	{
-		files: ["src/index.ts"],
-		rules: {
-			"import-x/order": "off",
-		},
-	},
-];
+const config: Linter.Config[] = [...strict];
 
 export default config;

--- a/packages/framework/fluid-framework/eslint.config.mts
+++ b/packages/framework/fluid-framework/eslint.config.mts
@@ -6,6 +6,14 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		files: ["src/index.ts"],
+		rules: {
+			"import-x/order": "off",
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -104,6 +104,7 @@
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/fluid-static": "workspace:~",
 		"@fluidframework/map": "workspace:~",
+		"@fluidframework/presence": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~",

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -104,8 +104,13 @@ export const getPresence = getPresenceDeprecated;
  *
  * @alpha
  */
-// eslint-disable-next-line unicorn/prefer-export-from, import-x/no-deprecated -- TODO#59157: relocating to fluid-static
-export const getPresenceAlpha = getPresenceAlphaDeprecated;
+export const getPresenceAlpha: (
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- complicated redeclaration required to satisfy api-extractor
+	fluidContainer: import("@fluidframework/fluid-static").IFluidContainer,
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- complicated redeclaration required to satisfy api-extractor
+) => import("@fluidframework/presence/alpha").PresenceWithNotifications =
+	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
+	getPresenceAlphaDeprecated;
 
 import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 import type { ITree } from "@fluidframework/tree";

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -83,6 +83,30 @@ export * from "@fluidframework/tree/alpha";
 // ---------------------------------------------------------------
 // #region Custom re-exports
 
+import {
+	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
+	getPresence as getPresenceDeprecated,
+	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
+	getPresenceAlpha as getPresenceAlphaDeprecated,
+	// eslint-disable-next-line import-x/no-internal-modules -- presence has no /internal export, which would be allowed
+} from "@fluidframework/presence/alpha";
+
+/**
+ * {@inheritdoc @fluidframework/presence#getPresence}
+ *
+ * @beta
+ */
+// eslint-disable-next-line unicorn/prefer-export-from, import-x/no-deprecated -- TODO#59157: relocating to fluid-static
+export const getPresence = getPresenceDeprecated;
+
+/**
+ * {@inheritdoc @fluidframework/presence#getPresenceAlpha}
+ *
+ * @alpha
+ */
+// eslint-disable-next-line unicorn/prefer-export-from, import-x/no-deprecated -- TODO#59157: relocating to fluid-static
+export const getPresenceAlpha = getPresenceAlphaDeprecated;
+
 import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 import type { ITree } from "@fluidframework/tree";
 import {

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -82,6 +82,7 @@ export * from "@fluidframework/tree/alpha";
 // #endregion Basic re-exports
 // ---------------------------------------------------------------
 // #region Custom re-exports
+/* eslint-disable import-x/order */
 
 import {
 	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
@@ -161,6 +162,7 @@ export function configuredSharedTree(options: SharedTreeOptions): SharedObjectKi
 	return originalConfiguredSharedTree(options);
 }
 
+/* eslint-enable import-x/order */
 // #endregion Custom re-exports
 // #endregion
 

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -93,23 +93,15 @@ export type {
 	BroadcastControlSettings,
 	ClientConnectionId,
 	InternalPresenceTypes,
-	InternalPresenceUtilityTypes,
-	NotificationEmitter,
-	NotificationListenable,
-	NotificationsManager,
-	NotificationsManagerEvents,
-	NotificationsWorkspace,
-	NotificationsWorkspaceSchema,
 	Presence,
 	PresenceEvents,
-	PresenceWithNotifications,
 	StatesWorkspace,
 	StatesWorkspaceEntries,
 	StatesWorkspaceEntry,
 	StatesWorkspaceSchema,
 	WorkspaceAddress,
 	// eslint-disable-next-line import-x/no-internal-modules -- presence has no /internal export, which would be allowed
-} from "@fluidframework/presence/alpha";
+} from "@fluidframework/presence/beta";
 export {
 	AttendeeStatus,
 	// eslint-disable-next-line import-x/no-internal-modules -- presence has no /internal export, which would be allowed
@@ -136,12 +128,9 @@ export * from "@fluidframework/tree/alpha";
 import {
 	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
 	getPresence as getPresenceDeprecated,
-	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
-	getPresenceAlpha as getPresenceAlphaDeprecated,
 	type Presence,
-	type PresenceWithNotifications,
 	// eslint-disable-next-line import-x/no-internal-modules -- presence has no /internal export, which would be allowed
-} from "@fluidframework/presence/alpha";
+} from "@fluidframework/presence/beta";
 import type { IFluidContainer } from "@fluidframework/fluid-static";
 
 /**
@@ -152,15 +141,6 @@ import type { IFluidContainer } from "@fluidframework/fluid-static";
 export const getPresence: (fluidContainer: IFluidContainer) => Presence =
 	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
 	getPresenceDeprecated;
-
-/**
- * {@inheritdoc @fluidframework/presence#getPresenceAlpha}
- *
- * @alpha
- */
-export const getPresenceAlpha: (fluidContainer: IFluidContainer) => PresenceWithNotifications =
-	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
-	getPresenceAlphaDeprecated;
 
 import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 import type { ITree } from "@fluidframework/tree";

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -92,10 +92,8 @@ export type {
 	BroadcastControls,
 	BroadcastControlSettings,
 	ClientConnectionId,
-	// renamed to avoid collision with tree export
-	InternalTypes as InternalPresenceTypes,
-	// renamed to avoid collision with other similar package exports
-	InternalUtilityTypes as InternalPresenceUtilityTypes,
+	InternalPresenceTypes,
+	InternalPresenceUtilityTypes,
 	NotificationEmitter,
 	NotificationListenable,
 	NotificationsManager,

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -141,6 +141,7 @@ import {
 	getPresence as getPresenceDeprecated,
 	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
 	getPresenceAlpha as getPresenceAlphaDeprecated,
+	type Presence,
 	type PresenceWithNotifications,
 	// eslint-disable-next-line import-x/no-internal-modules -- presence has no /internal export, which would be allowed
 } from "@fluidframework/presence/alpha";
@@ -151,8 +152,9 @@ import type { IFluidContainer } from "@fluidframework/fluid-static";
  *
  * @beta
  */
-// eslint-disable-next-line unicorn/prefer-export-from, import-x/no-deprecated -- TODO#59157: relocating to fluid-static
-export const getPresence = getPresenceDeprecated;
+export const getPresence: (fluidContainer: IFluidContainer) => Presence =
+	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
+	getPresenceDeprecated;
 
 /**
  * {@inheritdoc @fluidframework/presence#getPresenceAlpha}

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -67,8 +67,7 @@ export type {
 	DeepReadonlyOptions,
 	DeepReadonlyRecursionLimit,
 	DeepReadonlySupportedGenericsDefault,
-	// renamed to avoid collision with other similar package exports
-	InternalUtilityTypes as InternalCoreInterfacesUtilityTypes,
+	InternalCoreInterfacesUtilityTypes,
 	JsonDeserialized,
 	JsonDeserializedOptions,
 	JsonSerializable,

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -61,10 +61,62 @@ export type {
 	Off,
 	/* eslint-enable import-x/export */
 } from "@fluidframework/core-interfaces";
-export type { ErasedBaseType } from "@fluidframework/core-interfaces/internal";
+export type { BrandedType, ErasedBaseType } from "@fluidframework/core-interfaces/internal";
+export type {
+	DeepReadonly,
+	DeepReadonlyOptions,
+	DeepReadonlyRecursionLimit,
+	DeepReadonlySupportedGenericsDefault,
+	// renamed to avoid collision with other similar package exports
+	InternalUtilityTypes as InternalCoreInterfacesUtilityTypes,
+	JsonDeserialized,
+	JsonDeserializedOptions,
+	JsonSerializable,
+	JsonSerializableOptions,
+	JsonTypeWith,
+	NonNullJsonObjectWith,
+	OpaqueJsonDeserialized,
+	OpaqueJsonSerializable,
+	ReadonlyJsonTypeWith,
+	ReadonlySupportedGenerics,
+	SerializationErrorPerNonPublicProperties,
+	SerializationErrorPerUndefinedArrayElement,
+} from "@fluidframework/core-interfaces/internal/exposedUtilityTypes";
 
 // This is an alpha API, but this package doesn't have an alpha entry point so its imported from "internal".
 export { onAssertionFailure } from "@fluidframework/core-utils/internal";
+
+export type {
+	Attendee,
+	AttendeeId,
+	AttendeesEvents,
+	BroadcastControls,
+	BroadcastControlSettings,
+	ClientConnectionId,
+	// renamed to avoid collision with tree export
+	InternalTypes as InternalPresenceTypes,
+	// renamed to avoid collision with other similar package exports
+	InternalUtilityTypes as InternalPresenceUtilityTypes,
+	NotificationEmitter,
+	NotificationListenable,
+	NotificationsManager,
+	NotificationsManagerEvents,
+	NotificationsWorkspace,
+	NotificationsWorkspaceSchema,
+	Presence,
+	PresenceEvents,
+	PresenceWithNotifications,
+	StatesWorkspace,
+	StatesWorkspaceEntries,
+	StatesWorkspaceEntry,
+	StatesWorkspaceSchema,
+	WorkspaceAddress,
+	// eslint-disable-next-line import-x/no-internal-modules -- presence has no /internal export, which would be allowed
+} from "@fluidframework/presence/alpha";
+export {
+	AttendeeStatus,
+	// eslint-disable-next-line import-x/no-internal-modules -- presence has no /internal export, which would be allowed
+} from "@fluidframework/presence/beta";
 
 export type { isFluidHandle } from "@fluidframework/runtime-utils";
 
@@ -89,8 +141,10 @@ import {
 	getPresence as getPresenceDeprecated,
 	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
 	getPresenceAlpha as getPresenceAlphaDeprecated,
+	type PresenceWithNotifications,
 	// eslint-disable-next-line import-x/no-internal-modules -- presence has no /internal export, which would be allowed
 } from "@fluidframework/presence/alpha";
+import type { IFluidContainer } from "@fluidframework/fluid-static";
 
 /**
  * {@inheritdoc @fluidframework/presence#getPresence}
@@ -105,11 +159,7 @@ export const getPresence = getPresenceDeprecated;
  *
  * @alpha
  */
-export const getPresenceAlpha: (
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- complicated redeclaration required to satisfy api-extractor
-	fluidContainer: import("@fluidframework/fluid-static").IFluidContainer,
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- complicated redeclaration required to satisfy api-extractor
-) => import("@fluidframework/presence/alpha").PresenceWithNotifications =
+export const getPresenceAlpha: (fluidContainer: IFluidContainer) => PresenceWithNotifications =
 	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
 	getPresenceAlphaDeprecated;
 

--- a/packages/framework/presence/README.md
+++ b/packages/framework/presence/README.md
@@ -203,7 +203,7 @@ function logOthersCounters(counterTracker: LatestMap<number, string>): void {
 To access Presence APIs, use `getPresence()` with any `IFluidContainer`.
 
 ```typescript
-import { getPresence } from "@fluidframework/presence/beta";
+import { getPresence } from "fluid-framework/beta";
 
 function usePresence(container: IFluidContainer): void {
    const presence = getPresence(container);

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -56,7 +56,7 @@ export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithNotifications;
 
 // @beta @system
-export namespace InternalTypes {
+export namespace InternalPresenceTypes {
     // @system
     export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
         instanceBase: new (...args: any[]) => unknown;
@@ -122,11 +122,11 @@ export namespace InternalTypes {
 }
 
 // @alpha @system
-export namespace InternalUtilityTypes {
+export namespace InternalPresenceUtilityTypes {
     // @system
-    export type IfNotificationParametersSignature<Event, IfParametersValid, Else> = Event extends (...args: infer P) => void ? InternalUtilityTypes_2.IfSameType<P, JsonSerializable<P>, IfParametersValid, Else> : Else;
+    export type IfNotificationParametersSignature<Event, IfParametersValid, Else> = Event extends (...args: infer P) => void ? InternalUtilityTypes.IfSameType<P, JsonSerializable<P>, IfParametersValid, Else> : Else;
     // @system
-    export type IfNotificationSubscriberSignature<Event, IfSubscriber, Else> = Event extends (sender: Attendee, ...args: infer P) => void ? InternalUtilityTypes_2.IfSameType<P, JsonSerializable<P>, IfSubscriber, Else> : Else;
+    export type IfNotificationSubscriberSignature<Event, IfSubscriber, Else> = Event extends (sender: Attendee, ...args: infer P) => void ? InternalUtilityTypes.IfSameType<P, JsonSerializable<P>, IfSubscriber, Else> : Else;
     // @system
     export type JsonDeserializedParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonDeserialized<P> : never;
     // @system
@@ -196,8 +196,8 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 
 // @beta @sealed
 export interface LatestFactory {
-    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
-    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 }
 
 // @beta @sealed
@@ -252,8 +252,8 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
 
 // @beta @sealed
 export interface LatestMapFactory {
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 }
 
 // @beta @sealed
@@ -287,25 +287,25 @@ export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
 
 // @alpha @sealed
-export interface NotificationEmitter<E extends InternalUtilityTypes.NotificationListeners<E>> {
-    broadcast<K extends keyof InternalUtilityTypes.NotificationListeners<E>>(notificationName: K, ...args: Parameters<E[K]>): void;
-    unicast<K extends keyof InternalUtilityTypes.NotificationListeners<E>>(notificationName: K, targetAttendee: Attendee, ...args: Parameters<E[K]>): void;
+export interface NotificationEmitter<E extends InternalPresenceUtilityTypes.NotificationListeners<E>> {
+    broadcast<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<E>>(notificationName: K, ...args: Parameters<E[K]>): void;
+    unicast<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<E>>(notificationName: K, targetAttendee: Attendee, ...args: Parameters<E[K]>): void;
 }
 
 // @alpha @sealed
-export interface NotificationListenable<TListeners extends InternalUtilityTypes.NotificationListeners<TListeners>> {
-    off<K extends keyof InternalUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): void;
-    on<K extends keyof InternalUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): Off;
+export interface NotificationListenable<TListeners extends InternalPresenceUtilityTypes.NotificationListeners<TListeners>> {
+    off<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): void;
+    on<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): Off;
 }
 
 // @alpha
-export function Notifications<T extends InternalUtilityTypes.NotificationListeners<T>, Key extends string = string>(initialSubscriptions: Partial<NotificationSubscriberSignatures<T>>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<T>>;
+export function Notifications<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string = string>(initialSubscriptions: Partial<NotificationSubscriberSignatures<T>>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
 
 // @alpha
-export function Notifications<TSubscriptions extends InternalUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<InternalUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
+export function Notifications<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
-export interface NotificationsManager<T extends InternalUtilityTypes.NotificationListeners<T>> {
+export interface NotificationsManager<T extends InternalPresenceUtilityTypes.NotificationListeners<T>> {
     readonly emit: NotificationEmitter<T>;
     readonly events: Listenable<NotificationsManagerEvents>;
     readonly notifications: NotificationListenable<T>;
@@ -319,13 +319,13 @@ export interface NotificationsManagerEvents {
 }
 
 // @alpha @sealed
-export type NotificationSubscriberSignatures<E extends InternalUtilityTypes.NotificationListeners<E>> = {
-    [K in keyof InternalUtilityTypes.NotificationListeners<E>]: (sender: Attendee, ...args: InternalUtilityTypes.JsonDeserializedParameters<E[K]>) => void;
+export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTypes.NotificationListeners<E>> = {
+    [K in keyof InternalPresenceUtilityTypes.NotificationListeners<E>]: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<E[K]>) => void;
 };
 
 // @alpha @sealed
 export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>>;
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>>;
     readonly notifications: StatesWorkspaceEntries<TSchema>;
     readonly presence: PresenceWithNotifications;
 }
@@ -333,7 +333,7 @@ export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSc
 // @alpha
 export interface NotificationsWorkspaceSchema {
     // (undocumented)
-    [key: string]: InternalTypes.ManagerFactory<typeof key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>>;
+    [key: string]: InternalPresenceTypes.ManagerFactory<typeof key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
 }
 
 // @beta @sealed
@@ -403,7 +403,7 @@ unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
 export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
     readonly states: StatesWorkspaceEntries<TSchema>;
@@ -414,15 +414,15 @@ export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
     /**
     * Registered State objects.
     */
-    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalTypes.StateValue<infer TManager> ? TManager : never;
+    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
 // @beta
-export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalTypes.ManagerFactory<TKey, TValue, TManager>;
+export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
 // @beta
 export interface StatesWorkspaceSchema {
-    [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<unknown>>;
+    [key: string]: StatesWorkspaceEntry<typeof key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
 }
 
 // @beta @system

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -49,10 +49,10 @@ export interface BroadcastControlSettings {
 // @beta
 export type ClientConnectionId = string;
 
-// @beta
+// @beta @deprecated
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
-// @alpha
+// @alpha @deprecated
 export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithNotifications;
 
 // @beta @system

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -52,7 +52,7 @@ export type ClientConnectionId = string;
 // @beta @deprecated
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
-// @alpha @deprecated
+// @alpha
 export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithNotifications;
 
 // @beta @system

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -49,7 +49,7 @@ export interface BroadcastControlSettings {
 // @beta
 export type ClientConnectionId = string;
 
-// @beta
+// @beta @deprecated
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @beta @system

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -53,7 +53,7 @@ export type ClientConnectionId = string;
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @beta @system
-export namespace InternalTypes {
+export namespace InternalPresenceTypes {
     // @system
     export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
         instanceBase: new (...args: any[]) => unknown;
@@ -167,8 +167,8 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 
 // @beta @sealed
 export interface LatestFactory {
-    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
-    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 }
 
 // @beta @sealed
@@ -223,8 +223,8 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
 
 // @beta @sealed
 export interface LatestMapFactory {
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 }
 
 // @beta @sealed
@@ -316,7 +316,7 @@ unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
 export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
     readonly states: StatesWorkspaceEntries<TSchema>;
@@ -327,15 +327,15 @@ export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
     /**
     * Registered State objects.
     */
-    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalTypes.StateValue<infer TManager> ? TManager : never;
+    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
 // @beta
-export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalTypes.ManagerFactory<TKey, TValue, TManager>;
+export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
 // @beta
 export interface StatesWorkspaceSchema {
-    [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<unknown>>;
+    [key: string]: StatesWorkspaceEntry<typeof key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
 }
 
 // @beta @system

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -59,7 +59,7 @@ export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithN
 export function getPresenceFromDataStoreContext(context: IFluidDataStoreContext): Presence;
 
 // @beta @system
-export namespace InternalTypes {
+export namespace InternalPresenceTypes {
     // @system
     export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
         instanceBase: new (...args: any[]) => unknown;
@@ -125,11 +125,11 @@ export namespace InternalTypes {
 }
 
 // @alpha @system
-export namespace InternalUtilityTypes {
+export namespace InternalPresenceUtilityTypes {
     // @system
-    export type IfNotificationParametersSignature<Event, IfParametersValid, Else> = Event extends (...args: infer P) => void ? InternalUtilityTypes_2.IfSameType<P, JsonSerializable<P>, IfParametersValid, Else> : Else;
+    export type IfNotificationParametersSignature<Event, IfParametersValid, Else> = Event extends (...args: infer P) => void ? InternalUtilityTypes.IfSameType<P, JsonSerializable<P>, IfParametersValid, Else> : Else;
     // @system
-    export type IfNotificationSubscriberSignature<Event, IfSubscriber, Else> = Event extends (sender: Attendee, ...args: infer P) => void ? InternalUtilityTypes_2.IfSameType<P, JsonSerializable<P>, IfSubscriber, Else> : Else;
+    export type IfNotificationSubscriberSignature<Event, IfSubscriber, Else> = Event extends (sender: Attendee, ...args: infer P) => void ? InternalUtilityTypes.IfSameType<P, JsonSerializable<P>, IfSubscriber, Else> : Else;
     // @system
     export type JsonDeserializedParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonDeserialized<P> : never;
     // @system
@@ -199,8 +199,8 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 
 // @beta @sealed
 export interface LatestFactory {
-    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
-    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 }
 
 // @beta @sealed
@@ -255,8 +255,8 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
 
 // @beta @sealed
 export interface LatestMapFactory {
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 }
 
 // @beta @sealed
@@ -290,25 +290,25 @@ export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
 
 // @alpha @sealed
-export interface NotificationEmitter<E extends InternalUtilityTypes.NotificationListeners<E>> {
-    broadcast<K extends keyof InternalUtilityTypes.NotificationListeners<E>>(notificationName: K, ...args: Parameters<E[K]>): void;
-    unicast<K extends keyof InternalUtilityTypes.NotificationListeners<E>>(notificationName: K, targetAttendee: Attendee, ...args: Parameters<E[K]>): void;
+export interface NotificationEmitter<E extends InternalPresenceUtilityTypes.NotificationListeners<E>> {
+    broadcast<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<E>>(notificationName: K, ...args: Parameters<E[K]>): void;
+    unicast<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<E>>(notificationName: K, targetAttendee: Attendee, ...args: Parameters<E[K]>): void;
 }
 
 // @alpha @sealed
-export interface NotificationListenable<TListeners extends InternalUtilityTypes.NotificationListeners<TListeners>> {
-    off<K extends keyof InternalUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): void;
-    on<K extends keyof InternalUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): Off;
+export interface NotificationListenable<TListeners extends InternalPresenceUtilityTypes.NotificationListeners<TListeners>> {
+    off<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): void;
+    on<K extends keyof InternalPresenceUtilityTypes.NotificationListeners<TListeners>>(notificationName: K, listener: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<TListeners[K]>) => void): Off;
 }
 
 // @alpha
-export function Notifications<T extends InternalUtilityTypes.NotificationListeners<T>, Key extends string = string>(initialSubscriptions: Partial<NotificationSubscriberSignatures<T>>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<T>>;
+export function Notifications<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string = string>(initialSubscriptions: Partial<NotificationSubscriberSignatures<T>>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
 
 // @alpha
-export function Notifications<TSubscriptions extends InternalUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<InternalUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
+export function Notifications<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
-export interface NotificationsManager<T extends InternalUtilityTypes.NotificationListeners<T>> {
+export interface NotificationsManager<T extends InternalPresenceUtilityTypes.NotificationListeners<T>> {
     readonly emit: NotificationEmitter<T>;
     readonly events: Listenable<NotificationsManagerEvents>;
     readonly notifications: NotificationListenable<T>;
@@ -322,13 +322,13 @@ export interface NotificationsManagerEvents {
 }
 
 // @alpha @sealed
-export type NotificationSubscriberSignatures<E extends InternalUtilityTypes.NotificationListeners<E>> = {
-    [K in keyof InternalUtilityTypes.NotificationListeners<E>]: (sender: Attendee, ...args: InternalUtilityTypes.JsonDeserializedParameters<E[K]>) => void;
+export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTypes.NotificationListeners<E>> = {
+    [K in keyof InternalPresenceUtilityTypes.NotificationListeners<E>]: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<E[K]>) => void;
 };
 
 // @alpha @sealed
 export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>>;
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>>;
     readonly notifications: StatesWorkspaceEntries<TSchema>;
     readonly presence: PresenceWithNotifications;
 }
@@ -336,7 +336,7 @@ export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSc
 // @alpha
 export interface NotificationsWorkspaceSchema {
     // (undocumented)
-    [key: string]: InternalTypes.ManagerFactory<typeof key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>>;
+    [key: string]: InternalPresenceTypes.ManagerFactory<typeof key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
 }
 
 // @beta @sealed
@@ -406,7 +406,7 @@ unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
 export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
     readonly states: StatesWorkspaceEntries<TSchema>;
@@ -417,15 +417,15 @@ export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
     /**
     * Registered State objects.
     */
-    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalTypes.StateValue<infer TManager> ? TManager : never;
+    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
 // @beta
-export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalTypes.ManagerFactory<TKey, TValue, TManager>;
+export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
 // @beta
 export interface StatesWorkspaceSchema {
-    [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<unknown>>;
+    [key: string]: StatesWorkspaceEntry<typeof key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
 }
 
 // @beta @system

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -49,10 +49,10 @@ export interface BroadcastControlSettings {
 // @beta
 export type ClientConnectionId = string;
 
-// @beta
+// @beta @deprecated
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
-// @alpha
+// @alpha @deprecated
 export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithNotifications;
 
 // @alpha @legacy

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -52,7 +52,7 @@ export type ClientConnectionId = string;
 // @beta @deprecated
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
-// @alpha @deprecated
+// @alpha
 export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithNotifications;
 
 // @alpha @legacy

--- a/packages/framework/presence/src/exposedInternalTypes.ts
+++ b/packages/framework/presence/src/exposedInternalTypes.ts
@@ -29,7 +29,7 @@ export namespace InternalTypes {
 	 * And it includes standard metadata.
 	 *
 	 * @remarks
-	 * See {@link @fluidframework/presence#InternalTypes.ValueRequiredState}.
+	 * See {@link InternalPresenceTypes.ValueRequiredState}.
 	 *
 	 * @system
 	 */
@@ -53,7 +53,7 @@ export namespace InternalTypes {
 	 * need to specify some wrapper themselves.
 	 *
 	 * For known cases, construct a custom interface that extends
-	 * {@link @fluidframework/presence#InternalTypes.ValueStateMetadata}.
+	 * {@link InternalPresenceTypes.ValueStateMetadata}.
 	 *
 	 * @system
 	 */

--- a/packages/framework/presence/src/exposedInternalTypes.ts
+++ b/packages/framework/presence/src/exposedInternalTypes.ts
@@ -29,7 +29,7 @@ export namespace InternalTypes {
 	 * And it includes standard metadata.
 	 *
 	 * @remarks
-	 * See {@link InternalTypes.ValueRequiredState}.
+	 * See {@link @fluidframework/presence#InternalTypes.ValueRequiredState}.
 	 *
 	 * @system
 	 */
@@ -53,7 +53,7 @@ export namespace InternalTypes {
 	 * need to specify some wrapper themselves.
 	 *
 	 * For known cases, construct a custom interface that extends
-	 * {@link InternalTypes.ValueStateMetadata}.
+	 * {@link @fluidframework/presence#InternalTypes.ValueStateMetadata}.
 	 *
 	 * @system
 	 */

--- a/packages/framework/presence/src/exposedUtilityTypes.ts
+++ b/packages/framework/presence/src/exposedUtilityTypes.ts
@@ -4,7 +4,7 @@
  */
 
 import type {
-	InternalUtilityTypes as CoreInternalUtilityTypes,
+	InternalCoreInterfacesUtilityTypes,
 	JsonDeserialized,
 	JsonSerializable,
 } from "@fluidframework/core-interfaces/internal/exposedUtilityTypes";
@@ -28,7 +28,12 @@ export namespace InternalUtilityTypes {
 	 */
 	export type IfNotificationParametersSignature<Event, IfParametersValid, Else> =
 		Event extends (...args: infer P) => void
-			? CoreInternalUtilityTypes.IfSameType<P, JsonSerializable<P>, IfParametersValid, Else>
+			? InternalCoreInterfacesUtilityTypes.IfSameType<
+					P,
+					JsonSerializable<P>,
+					IfParametersValid,
+					Else
+				>
 			: Else;
 
 	/**
@@ -41,7 +46,7 @@ export namespace InternalUtilityTypes {
 		sender: Attendee,
 		...args: infer P
 	) => void
-		? CoreInternalUtilityTypes.IfSameType<P, JsonSerializable<P>, IfSubscriber, Else>
+		? InternalCoreInterfacesUtilityTypes.IfSameType<P, JsonSerializable<P>, IfSubscriber, Else>
 		: Else;
 
 	/**

--- a/packages/framework/presence/src/getPresence.ts
+++ b/packages/framework/presence/src/getPresence.ts
@@ -15,7 +15,7 @@ import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { IFluidContainer } from "@fluidframework/fluid-static";
 import { isInternalFluidContainer } from "@fluidframework/fluid-static/internal";
 import type {
-	ExtensionCompatibilityDetails,
+	ExtensionCompatibilityDetails as getPresenceAlphaDeprecated,
 	FluidDataStoreContextInternal,
 	IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -23,7 +23,7 @@ import type {
 import { pkgVersion } from "./packageVersion.js";
 import type { Presence, PresenceWithNotifications } from "./presence.js";
 import type { PresenceExtensionInterface } from "./presenceManager.js";
-import { createPresenceManager } from "./presenceManager.js";
+import { createPresenceManager as getPresenceDeprecated } from "./presenceManager.js";
 import type { SignalMessages } from "./protocol.js";
 import type { ExtensionHost, ExtensionRuntimeProperties } from "./runtimeTypes.js";
 
@@ -31,7 +31,7 @@ const presenceCompatibility = {
 	generation: 1,
 	version: pkgVersion,
 	capabilities: new Set([]),
-} as const satisfies ExtensionCompatibilityDetails;
+} as const satisfies getPresenceAlphaDeprecated;
 
 /**
  * Minimal compatible package version.
@@ -41,7 +41,7 @@ const presenceCompatibility = {
  */
 const minimalCompatiblePackageVersion = "2.71.0";
 
-function assertCompatibilityInvariants(compatibility: ExtensionCompatibilityDetails): void {
+function assertCompatibilityInvariants(compatibility: getPresenceAlphaDeprecated): void {
 	assert(
 		compatibility.generation === presenceCompatibility.generation,
 		0xc97 /* Presence compatibility generation mismatch. */,
@@ -82,7 +82,7 @@ class ContainerPresenceManager
 	private readonly manager: PresenceExtensionInterface;
 
 	public constructor(host: ExtensionHost) {
-		this.interface = this.manager = createPresenceManager({
+		this.interface = this.manager = getPresenceDeprecated({
 			...host,
 			submitSignal: (message) => {
 				host.submitAddressedSignal([], message);
@@ -94,7 +94,7 @@ class ContainerPresenceManager
 		ourExistingInstantiation: Readonly<
 			ExtensionInstantiationResult<PresenceWithNotifications, ExtensionRuntimeProperties, []>
 		>,
-		newCompatibilityRequest: ExtensionCompatibilityDetails,
+		newCompatibilityRequest: getPresenceAlphaDeprecated,
 	): never {
 		assert(
 			ourExistingInstantiation.compatibility === presenceCompatibility,
@@ -161,6 +161,8 @@ const ContainerPresenceFactory = {
  * @returns the {@link Presence}
  *
  * @beta
+ *
+ * @deprecated Import from `fluid-framework/beta` instead. The export to be removed in 2.100.0 release.
  */
 export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPresenceAlpha;
 
@@ -170,6 +172,8 @@ export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPre
  * @returns the {@link PresenceWithNotifications}
  *
  * @alpha
+ *
+ * @deprecated Import from `fluid-framework/alpha` instead. The export to be removed in 2.100.0 release.
  */
 export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithNotifications {
 	assert(

--- a/packages/framework/presence/src/getPresence.ts
+++ b/packages/framework/presence/src/getPresence.ts
@@ -15,7 +15,7 @@ import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { IFluidContainer } from "@fluidframework/fluid-static";
 import { isInternalFluidContainer } from "@fluidframework/fluid-static/internal";
 import type {
-	ExtensionCompatibilityDetails as getPresenceAlphaDeprecated,
+	ExtensionCompatibilityDetails,
 	FluidDataStoreContextInternal,
 	IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -23,7 +23,7 @@ import type {
 import { pkgVersion } from "./packageVersion.js";
 import type { Presence, PresenceWithNotifications } from "./presence.js";
 import type { PresenceExtensionInterface } from "./presenceManager.js";
-import { createPresenceManager as getPresenceDeprecated } from "./presenceManager.js";
+import { createPresenceManager } from "./presenceManager.js";
 import type { SignalMessages } from "./protocol.js";
 import type { ExtensionHost, ExtensionRuntimeProperties } from "./runtimeTypes.js";
 
@@ -31,7 +31,7 @@ const presenceCompatibility = {
 	generation: 1,
 	version: pkgVersion,
 	capabilities: new Set([]),
-} as const satisfies getPresenceAlphaDeprecated;
+} as const satisfies ExtensionCompatibilityDetails;
 
 /**
  * Minimal compatible package version.
@@ -41,7 +41,7 @@ const presenceCompatibility = {
  */
 const minimalCompatiblePackageVersion = "2.71.0";
 
-function assertCompatibilityInvariants(compatibility: getPresenceAlphaDeprecated): void {
+function assertCompatibilityInvariants(compatibility: ExtensionCompatibilityDetails): void {
 	assert(
 		compatibility.generation === presenceCompatibility.generation,
 		0xc97 /* Presence compatibility generation mismatch. */,
@@ -82,7 +82,7 @@ class ContainerPresenceManager
 	private readonly manager: PresenceExtensionInterface;
 
 	public constructor(host: ExtensionHost) {
-		this.interface = this.manager = getPresenceDeprecated({
+		this.interface = this.manager = createPresenceManager({
 			...host,
 			submitSignal: (message) => {
 				host.submitAddressedSignal([], message);
@@ -94,7 +94,7 @@ class ContainerPresenceManager
 		ourExistingInstantiation: Readonly<
 			ExtensionInstantiationResult<PresenceWithNotifications, ExtensionRuntimeProperties, []>
 		>,
-		newCompatibilityRequest: getPresenceAlphaDeprecated,
+		newCompatibilityRequest: ExtensionCompatibilityDetails,
 	): never {
 		assert(
 			ourExistingInstantiation.compatibility === presenceCompatibility,

--- a/packages/framework/presence/src/getPresence.ts
+++ b/packages/framework/presence/src/getPresence.ts
@@ -162,7 +162,7 @@ const ContainerPresenceFactory = {
  *
  * @beta
  *
- * @deprecated Import from `fluid-framework/beta` instead. The export is to be removed in 2.100.0 release.
+ * @deprecated Import from `fluid-framework/beta` instead. This export will be removed in the 2.100.0 release.
  */
 export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPresenceAlpha;
 
@@ -173,7 +173,7 @@ export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPre
  *
  * @alpha
  *
- * @deprecated Import from `fluid-framework/alpha` instead. The export is to be removed in 2.100.0 release.
+ * @deprecated Import from `fluid-framework/alpha` instead. This export will be removed in the 2.100.0 release.
  */
 export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithNotifications {
 	assert(

--- a/packages/framework/presence/src/getPresence.ts
+++ b/packages/framework/presence/src/getPresence.ts
@@ -162,7 +162,7 @@ const ContainerPresenceFactory = {
  *
  * @beta
  *
- * @deprecated Import from `fluid-framework/beta` instead. The export to be removed in 2.100.0 release.
+ * @deprecated Import from `fluid-framework/beta` instead. The export is to be removed in 2.100.0 release.
  */
 export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPresenceAlpha;
 
@@ -173,7 +173,7 @@ export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPre
  *
  * @alpha
  *
- * @deprecated Import from `fluid-framework/alpha` instead. The export to be removed in 2.100.0 release.
+ * @deprecated Import from `fluid-framework/alpha` instead. The export is to be removed in 2.100.0 release.
  */
 export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithNotifications {
 	assert(

--- a/packages/framework/presence/src/getPresence.ts
+++ b/packages/framework/presence/src/getPresence.ts
@@ -171,9 +171,12 @@ export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPre
  * @param fluidContainer - Fluid Container to acquire the map from
  * @returns the {@link PresenceWithNotifications}
  *
- * @alpha
+ * @remarks
+ * Notice! This export will be removed in the 2.100.0 release. It will be resurfaced
+ * via `@fluidframework/fluid-static/alpha` prior to removal. Since this is an `@alpha`
+ * API be sure that package dependencies are using exact or minor only (~) range spec.
  *
- * @deprecated Import from `fluid-framework/alpha` instead. This export will be removed in the 2.100.0 release.
+ * @alpha
  */
 export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithNotifications {
 	assert(

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -89,5 +89,5 @@ export type {
 
 export { StateFactory } from "./stateFactory.js";
 
-export type { InternalTypes } from "./exposedInternalTypes.js";
-export type { InternalUtilityTypes } from "./exposedUtilityTypes.js";
+export type { InternalTypes as InternalPresenceTypes } from "./exposedInternalTypes.js";
+export type { InternalUtilityTypes as InternalPresenceUtilityTypes } from "./exposedUtilityTypes.js";

--- a/packages/framework/presence/src/internalUtils.ts
+++ b/packages/framework/presence/src/internalUtils.ts
@@ -5,7 +5,7 @@
 
 import type {
 	DeepReadonly,
-	InternalUtilityTypes,
+	InternalCoreInterfacesUtilityTypes,
 	JsonDeserialized,
 	JsonSerializable,
 	OpaqueJsonDeserialized,
@@ -186,9 +186,10 @@ type PickRemainder<T> =
  * property. (This can be fixed, but might be best addressed by changing
  * T to be a tuple of types to be combined.)
  */
-export type FlattenUnionWithOptionals<T> = InternalUtilityTypes.FlattenIntersection<
-	Pick<T, keyof T> & UnionToIntersection<Partial<PickRemainder<T>>>
->;
+export type FlattenUnionWithOptionals<T> =
+	InternalCoreInterfacesUtilityTypes.FlattenIntersection<
+		Pick<T, keyof T> & UnionToIntersection<Partial<PickRemainder<T>>>
+	>;
 
 /**
  * Type guard to check if a state is a required state (has a value).

--- a/packages/framework/presence/src/notificationsManagerTypes.ts
+++ b/packages/framework/presence/src/notificationsManagerTypes.ts
@@ -119,7 +119,7 @@ export interface NotificationEmitter<E extends InternalUtilityTypes.Notification
  * Provides notifications from this client to others and subscription
  * to their notifications.
  *
- * @remarks Create using {@link (Notifications:1)} registered to
+ * @remarks Create using {@link @fluidframework/presence#(Notifications:1)} registered to
  * {@link NotificationsWorkspace} or {@link StatesWorkspace}.
  *
  * @sealed

--- a/packages/framework/presence/src/test/testUtils.ts
+++ b/packages/framework/presence/src/test/testUtils.ts
@@ -5,7 +5,7 @@
 
 import type { InboundExtensionMessage } from "@fluidframework/container-runtime-definitions/internal";
 import type {
-	InternalUtilityTypes,
+	InternalCoreInterfacesUtilityTypes,
 	JsonDeserialized,
 } from "@fluidframework/core-interfaces/internal";
 import type { EventAndErrorTrackingLogger } from "@fluidframework/test-utils/internal";
@@ -37,10 +37,10 @@ import { initialLocalClientConnectionId } from "./mockEphemeralRuntime.js";
  * Use to compile-time assert types of two variables are identical.
  */
 export function assertIdenticalTypes<T, U>(
-	_actual: T & InternalUtilityTypes.IfSameType<T, U>,
-	_expected: U & InternalUtilityTypes.IfSameType<T, U>,
-): InternalUtilityTypes.IfSameType<T, U> {
-	return undefined as InternalUtilityTypes.IfSameType<T, U>;
+	_actual: T & InternalCoreInterfacesUtilityTypes.IfSameType<T, U>,
+	_expected: U & InternalCoreInterfacesUtilityTypes.IfSameType<T, U>,
+): InternalCoreInterfacesUtilityTypes.IfSameType<T, U> {
+	return undefined as InternalCoreInterfacesUtilityTypes.IfSameType<T, U>;
 }
 
 /**

--- a/packages/framework/presence/src/types.ts
+++ b/packages/framework/presence/src/types.ts
@@ -28,7 +28,7 @@ import type { Presence, PresenceWithNotifications } from "./presence.js";
 export type WorkspaceAddress = `${string}:${string}`;
 
 /**
- * Single entry in {@link StatesWorkspaceSchema} or  {@link NotificationsWorkspaceSchema}.
+ * Single entry in {@link StatesWorkspaceSchema} or  {@link @fluidframework/presence#NotificationsWorkspaceSchema}.
  *
  * @beta
  */

--- a/packages/framework/presence/src/validatableTypes.ts
+++ b/packages/framework/presence/src/validatableTypes.ts
@@ -4,7 +4,7 @@
  */
 
 import type {
-	InternalUtilityTypes,
+	InternalCoreInterfacesUtilityTypes,
 	OpaqueJsonDeserialized,
 } from "@fluidframework/core-interfaces/internal";
 
@@ -86,13 +86,13 @@ export type ValidatableValueStructure<
 		| InternalTypes.ValueOptionalState<unknown>,
 > =
 	T extends InternalTypes.ValueDirectory<infer TValue>
-		? InternalUtilityTypes.IfSameType<
+		? InternalCoreInterfacesUtilityTypes.IfSameType<
 				T,
 				InternalTypes.ValueDirectory<T>,
 				// Use canonical type for exact match
 				ValidatableValueDirectory<TValue>,
 				// Inexact match => recurse
-				InternalUtilityTypes.FlattenIntersection<
+				InternalCoreInterfacesUtilityTypes.FlattenIntersection<
 					Omit<T, "items"> & {
 						items: {
 							[KItems in keyof T["items"]]: ValidatableValueStructure<T["items"][KItems]>;
@@ -103,7 +103,7 @@ export type ValidatableValueStructure<
 		: T extends
 					| InternalTypes.ValueRequiredState<infer TValue>
 					| InternalTypes.ValueOptionalState<infer TValue>
-			? InternalUtilityTypes.FlattenIntersection<
+			? InternalCoreInterfacesUtilityTypes.FlattenIntersection<
 					Omit<T, keyof ValidatableMetadata<TValue>> & ValidatableMetadata<TValue>
 				>
 			: never;

--- a/packages/runtime/container-runtime-definitions/src/containerExtension.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerExtension.ts
@@ -7,7 +7,7 @@ import type { ILayerCompatDetails } from "@fluid-internal/client-utils";
 import type { IAudience } from "@fluidframework/container-definitions/internal";
 import type {
 	BrandedType,
-	InternalUtilityTypes,
+	InternalCoreInterfacesUtilityTypes,
 	ITelemetryBaseLogger,
 	JsonDeserialized,
 	JsonSerializable,
@@ -46,7 +46,7 @@ export type ExtensionMessage<
 	},
 > = // `TMessage extends TypedMessage` encourages processing union elements individually
 	TMessage extends TypedMessage
-		? InternalUtilityTypes.FlattenIntersection<
+		? InternalCoreInterfacesUtilityTypes.FlattenIntersection<
 				TMessage & {
 					/**
 					 * Client ID of the singular client the message is being (or has been) sent to.
@@ -120,7 +120,7 @@ export declare class UnverifiedBrand<T> extends BrandedType<UnverifiedBrand<unkn
 export type RawInboundExtensionMessage<TMessage extends TypedMessage = TypedMessage> =
 	// `TMessage extends TypedMessage` encourages processing union elements individually
 	TMessage extends TypedMessage
-		? InternalUtilityTypes.FlattenIntersection<
+		? InternalCoreInterfacesUtilityTypes.FlattenIntersection<
 				ExtensionMessage<{
 					type: string;
 					content: OpaqueJsonDeserialized<unknown>;
@@ -145,7 +145,7 @@ export type RawInboundExtensionMessage<TMessage extends TypedMessage = TypedMess
 export type VerifiedInboundExtensionMessage<TMessage extends TypedMessage = TypedMessage> =
 	// `TMessage extends TypedMessage` encourages processing union elements individually
 	TMessage extends TypedMessage
-		? InternalUtilityTypes.FlattenIntersection<
+		? InternalCoreInterfacesUtilityTypes.FlattenIntersection<
 				ExtensionMessage<{
 					type: TMessage["type"];
 					content: unknown extends TMessage["content"]

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
@@ -19,6 +19,7 @@ import { LogLevel } from "@fluidframework/core-interfaces";
 import type { ScopeType } from "@fluidframework/driver-definitions/legacy";
 import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import {
+	// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
 	getPresence,
 	type Attendee,
 	type Presence,
@@ -487,6 +488,7 @@ class MessageHandler {
 				onDisconnected: this.onDisconnected,
 			});
 			this.container = container;
+			// eslint-disable-next-line import-x/no-deprecated -- TODO#59157: relocating to fluid-static
 			const presence = getPresence(container);
 			this.presence = presence;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11497,6 +11497,9 @@ importers:
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../dds/map
+      '@fluidframework/presence':
+        specifier: workspace:~
+        version: link:../presence
       '@fluidframework/runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/runtime-utils


### PR DESCRIPTION
- Promote `BrandedType` to `@beta`
- Export all of the collateral from `Presence` and `PresenceWithNotifications` from `fluid-framework`
- Retype `getPresence` so api-extractor doesn't list return type as `import("@fluidframework/presence/alpha").Presence`
- Qualify comments `{@link}`s that api-extractor doesn't follow well to the local package. (Qualified links are not validated and can show up as plain text or unfortunate cross-package links (when they don't need to be).